### PR TITLE
feat: add Claude Fable 5 support

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dorabot-desktop",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dorabot-desktop",
-      "version": "0.2.92",
+      "version": "0.2.93",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@monaco-editor/react": "4.7.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorabot-desktop",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "description": "Desktop control center for dorabot",
   "main": "out/main/main.js",
   "scripts": {

--- a/desktop/src/lib/modelCatalog.ts
+++ b/desktop/src/lib/modelCatalog.ts
@@ -40,6 +40,7 @@ const CODEX_FALLBACK_REASONING_EFFORTS: ReasoningEffortOption[] = [
 const CODEX_APP_SERVER_REASONING_EFFORTS = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']);
 
 export const CLAUDE_MODELS: ModelOption[] = [
+  { value: 'claude-fable-5', label: 'Fable 5' },
   { value: 'claude-opus-4-8', label: 'Opus 4.8' },
   { value: 'claude-opus-4-7', label: 'Opus 4.7' },
   { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "dorabot",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dorabot",
-      "version": "0.2.92",
+      "version": "0.2.93",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk": "0.3.170",
         "@anthropic-ai/sdk": "0.97.1",
         "@grammyjs/runner": "2.0.3",
         "@grammyjs/transformer-throttler": "1.2.1",
@@ -48,22 +48,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.154.tgz",
-      "integrity": "sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.170.tgz",
+      "integrity": "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.154",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.154"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.154.tgz",
-      "integrity": "sha512-oFW3LD5lYrKAU+AKu27Z8hrzqkrh362qQrwi/i3DxGcud9BXUycsXYjShpDj3D3JZu169UzZuSPhx1Wajmbiwg==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.170.tgz",
+      "integrity": "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==",
       "cpu": [
         "arm64"
       ],
@@ -85,9 +85,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.154.tgz",
-      "integrity": "sha512-5BgWEueP+cqoctWjZYhCbyltuaV/N2DmKDXD3/69cKaVmJp8XL9OCzlq/HEirA/+Ssjskx6hDUBaOcpuZ3iwQA==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.170.tgz",
+      "integrity": "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ==",
       "cpu": [
         "x64"
       ],
@@ -98,9 +98,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.154.tgz",
-      "integrity": "sha512-rRkW4SBL3W7zQvKscCIfIGlmoeuTbMV6dXFbPdmpRGvmYZIs79RpzO6xrGBnnhmm+B7znQ9oHAnffi/2FBgJbA==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.170.tgz",
+      "integrity": "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +114,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.154.tgz",
-      "integrity": "sha512-o2bCQN4Xn3UqCLErC5m4T7u0yYArJYmgFCUFnA6K96DdW2RERvx+gTKXxWuHEBkDO+eMoHLHLxk0u2jGES00Ng==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.170.tgz",
+      "integrity": "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.154.tgz",
-      "integrity": "sha512-GpiFF8Ez6PbM3m0gqtCo/FKM346qyRdP7VhbmJzdnbNKTiiUZ66vDQyEUPZPCG24ZkrG4m96KpRIUwY08rHiNg==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.170.tgz",
+      "integrity": "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg==",
       "cpu": [
         "x64"
       ],
@@ -146,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.154.tgz",
-      "integrity": "sha512-zA7S8Lm6O4QBsUpbhiOht8BgiXHOBBFUIo8ZLK6r5wAatK3Q44syWVxICeyCnR6wqfnkf3cugCw27ycS6vVgaA==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.170.tgz",
+      "integrity": "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +162,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.154.tgz",
-      "integrity": "sha512-cDW1YFbU/PJFlrGXhlAGcbkXt80sEO6WtnH8nN8YHXLn5NWduy2q7o/qC6i8XozgvRGf6t/eMoH7IasGIEDhDw==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.170.tgz",
+      "integrity": "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.154.tgz",
-      "integrity": "sha512-tSKaIIpL72OPg3WfzZTCIl8OJgcbq4qieu8/fDWjsdeQuari9gQMIuEflFphk9HqNsxpSmDqKi8Sm5mW2V566Q==",
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.170.tgz",
+      "integrity": "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorabot",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "type": "module",
   "description": "Open-source personal AI agent. Persistent memory, multi-channel messaging, browser automation, and proactive goal management.",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "test:model-catalog": "node scripts/test-model-catalog.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.154",
+    "@anthropic-ai/claude-agent-sdk": "0.3.170",
     "@anthropic-ai/sdk": "0.97.1",
     "@grammyjs/runner": "2.0.3",
     "@grammyjs/transformer-throttler": "1.2.1",

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -112,6 +112,7 @@ Focus on clarity and completeness. Flag any ambiguities.`,
 };
 
 const MODEL_MAP: Record<string, 'sonnet' | 'opus' | 'haiku' | 'inherit'> = {
+  'claude-fable-5': 'opus',
   'claude-opus-4-8': 'opus',
   'claude-opus-4-7': 'opus',
   'claude-sonnet-4-6': 'sonnet',

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -859,10 +859,11 @@ export class ClaudeProvider implements Provider {
       ? EFFORT_MAP[opts.config.reasoningEffort]
       : undefined;
 
-    // Build thinking config — auto-coerce to adaptive for 4.6+ models (budgetTokens deprecated/removed)
+    // Build thinking config — auto-coerce to adaptive for 4.6+ models and the Fable/Mythos family
+    // (adaptive thinking always-on, extended thinking / budgetTokens unsupported → 400)
     let thinking: { type: 'adaptive'; display?: 'summarized' | 'omitted' } | { type: 'enabled'; budgetTokens: number } | { type: 'disabled' } | undefined;
     const thinkingCfg = opts.config.thinking;
-    const modelNeedAdaptive = /claude-(?:opus|sonnet)-4-(?:[6-9]|\d{2,})(?:-|$)/.test(opts.model);
+    const modelNeedAdaptive = /claude-(?:opus|sonnet)-4-(?:[6-9]|\d{2,})(?:-|$)|claude-(?:fable|mythos)-/.test(opts.model);
     if (modelNeedAdaptive && thinkingCfg && typeof thinkingCfg === 'object' && 'type' in thinkingCfg && (thinkingCfg as any).type === 'enabled') {
       // budgetTokens is deprecated on 4.6, removed on 4.7 (returns 400) — force adaptive
       console.warn(`[claude] budgetTokens not supported on ${opts.model}, using adaptive thinking instead`);


### PR DESCRIPTION
Adds `claude-fable-5` — Anthropic's most capable widely-available model (the public, guardrailed Mythos-class model, GA on the Claude API as of 2026-06-09).

## Changes
- **Model catalog** (`desktop/src/lib/modelCatalog.ts`): add `Fable 5` to the selectable Claude models (top of list — it's the most capable GA model).
- **Subagent MODEL_MAP** (`src/agents/definitions.ts`): map `claude-fable-5` → `opus` tier.
- **Adaptive-thinking coercion** (`src/providers/claude.ts`): extend the regex so the Fable/Mythos family is treated like 4.6+ models — adaptive thinking is always-on and extended thinking / `budgetTokens` is unsupported (would 400), so `enabled` configs are coerced to `adaptive`.
- **SDK bump**: `@anthropic-ai/claude-agent-sdk` 0.3.154 → 0.3.170 so the bundled Claude Code CLI recognizes `claude-fable-5`.
- version 0.2.92 → 0.2.93.

## Notes
- **Mythos 5 (`claude-mythos-5`) intentionally not added** — it's limited to Project Glasswing partners and is not in the public CLI's model list, so it can't be wired here.
- Mirrors the prior `feat: add Claude Opus 4.8 support` commit pattern.

## Verification
- Backend `tsc` build: clean. Desktop `tsc --noEmit`: clean.
- Confirmed installed agent SDK 0.3.170 ships `claude-fable-5` in its model list.
- Built `dist/` reflects the new regex + MODEL_MAP entry.