### PR TITLE
Fix release publishing and macOS update restart loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,20 @@ jobs:
           AUTHORITY=$(echo "$SIG_INFO" | grep "Authority=Developer ID Application" | head -1)
           echo "Signature OK: $AUTHORITY ($TEAM)"
 
+      - name: Reconcile GitHub release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release upload "$TAG" \
+            desktop/release/*.zip \
+            desktop/release/*.zip.blockmap \
+            desktop/release/*.dmg \
+            desktop/release/*.dmg.blockmap \
+            desktop/release/latest-mac.yml \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
       - name: Add release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,14 +105,46 @@ jobs:
           fi
           gh release edit "$TAG" --notes "$NOTES" --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
+      - name: Verify updater release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          MANIFEST="desktop/release/latest-mac.yml"
+          RELEASE_ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name' --repo "$GITHUB_REPOSITORY")
+
+          for ASSET in latest-mac.yml $(sed -n 's/^[[:space:]]*- url: //p' "$MANIFEST"); do
+            if ! grep -Fxq "$ASSET" <<< "$RELEASE_ASSETS"; then
+              echo "::error::Release asset is missing: $ASSET"
+              exit 1
+            fi
+
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${ASSET}"
+            READY=false
+            for ATTEMPT in 1 2 3 4 5; do
+              if curl --fail --silent --show-error --head --location "$URL" >/dev/null; then
+                READY=true
+                break
+              fi
+              sleep 3
+            done
+
+            if [ "$READY" != "true" ]; then
+              echo "::error::Release asset is not downloadable: $ASSET"
+              exit 1
+            fi
+          done
+
       - name: Upload DMG
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dorabot-dmg
           path: desktop/release/*.dmg
+          if-no-files-found: error
 
       - name: Upload ZIP
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dorabot-zip
           path: desktop/release/*.zip
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,22 @@ jobs:
           echo "Synced desktop/package.json to $ROOT_VERSION"
         working-directory: desktop
 
-      - name: Delete existing release if any
+      - name: Reset release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          gh release delete "$TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          RELEASE_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --paginate \
+            --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+          for RELEASE_ID in $RELEASE_IDS; do
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"
+          done
+          gh release create "$TAG" \
+            --draft \
+            --title "${TAG#v}" \
+            --verify-tag \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Build & Package
         env:
@@ -62,7 +72,7 @@ jobs:
             exit 1
           fi
           echo "Verifying: $APP"
-          codesign --verify --strict --verbose=2 "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
           SIG_INFO=$(codesign -d --verbose=2 "$APP" 2>&1)
           if echo "$SIG_INFO" | grep -q "Signature=adhoc"; then
             echo "::error::App is ad-hoc signed (no certificate). This will break auto-updates."
@@ -77,6 +87,31 @@ jobs:
           TEAM=$(echo "$SIG_INFO" | grep "TeamIdentifier=" | head -1)
           AUTHORITY=$(echo "$SIG_INFO" | grep "Authority=Developer ID Application" | head -1)
           echo "Signature OK: $AUTHORITY ($TEAM)"
+
+      - name: Verify updater archive
+        run: |
+          ZIP=$(find desktop/release -maxdepth 1 -name '*.zip' -type f | head -1)
+          if [ -z "$ZIP" ]; then
+            echo "::error::No updater ZIP found"
+            exit 1
+          fi
+
+          EXPECTED_SHA512=$(awk '/- url: .*\.zip$/ { getline; sub(/^[[:space:]]*sha512: /, ""); print; exit }' desktop/release/latest-mac.yml)
+          ACTUAL_SHA512=$(openssl dgst -sha512 -binary "$ZIP" | openssl base64 -A)
+          if [ "$ACTUAL_SHA512" != "$EXPECTED_SHA512" ]; then
+            echo "::error::Updater ZIP checksum does not match latest-mac.yml"
+            exit 1
+          fi
+
+          EXTRACT_DIR=$(mktemp -d)
+          trap 'rm -rf "$EXTRACT_DIR"' EXIT
+          ditto -x -k "$ZIP" "$EXTRACT_DIR"
+          ARCHIVED_APP=$(find "$EXTRACT_DIR" -maxdepth 2 -name 'dorabot.app' -type d | head -1)
+          if [ -z "$ARCHIVED_APP" ]; then
+            echo "::error::Updater ZIP does not contain dorabot.app"
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$ARCHIVED_APP"
 
       - name: Reconcile GitHub release assets
         env:
@@ -103,34 +138,28 @@ jobs:
           else
             NOTES=$(git log --oneline --no-merges -20)
           fi
-          gh release edit "$TAG" --notes "$NOTES" --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh release edit "$TAG" --notes "$NOTES" --repo "$GITHUB_REPOSITORY"
 
-      - name: Verify updater release assets
+      - name: Verify draft release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           MANIFEST="desktop/release/latest-mac.yml"
+          RELEASE_COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --paginate \
+            --jq ".[] | select(.tag_name == \"$TAG\") | .id" \
+            | awk 'NF { count++ } END { print count + 0 }')
+          if [ "$RELEASE_COUNT" -ne 1 ]; then
+            echo "::error::Expected one release for $TAG, found $RELEASE_COUNT"
+            exit 1
+          fi
+
           RELEASE_ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name' --repo "$GITHUB_REPOSITORY")
 
           for ASSET in latest-mac.yml $(sed -n 's/^[[:space:]]*- url: //p' "$MANIFEST"); do
             if ! grep -Fxq "$ASSET" <<< "$RELEASE_ASSETS"; then
               echo "::error::Release asset is missing: $ASSET"
-              exit 1
-            fi
-
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${ASSET}"
-            READY=false
-            for ATTEMPT in 1 2 3 4 5; do
-              if curl --fail --silent --show-error --head --location "$URL" >/dev/null; then
-                READY=true
-                break
-              fi
-              sleep 3
-            done
-
-            if [ "$READY" != "true" ]; then
-              echo "::error::Release asset is not downloadable: $ASSET"
               exit 1
             fi
           done
@@ -148,3 +177,32 @@ jobs:
           name: dorabot-zip
           path: desktop/release/*.zip
           if-no-files-found: error
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release edit "$TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
+
+      - name: Verify public updater release
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          MANIFEST="desktop/release/latest-mac.yml"
+
+          for ASSET in latest-mac.yml $(sed -n 's/^[[:space:]]*- url: //p' "$MANIFEST"); do
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${ASSET}"
+            READY=false
+            for ATTEMPT in 1 2 3 4 5; do
+              if curl --fail --silent --show-error --head --location "$URL" >/dev/null; then
+                READY=true
+                break
+              fi
+              sleep 3
+            done
+
+            if [ "$READY" != "true" ]; then
+              echo "::error::Release asset is not downloadable: $ASSET"
+              exit 1
+            fi
+          done

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -6,7 +6,7 @@ publish:
   provider: github
   owner: suitedaces
   repo: dorabot
-  releaseType: release
+  releaseType: draft
 
 directories:
   output: release

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -24,6 +24,7 @@ let isQuitting = false;
 let gatewayManager: GatewayManager | null = null;
 let gatewayBridge: GatewayBridge | null = null;
 let updateCheckInterval: ReturnType<typeof setInterval> | null = null;
+let updateInstallStarted = false;
 
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSingleInstanceLock) {
@@ -82,6 +83,10 @@ function setupAutoUpdater(): void {
   });
 
   autoUpdater.on('error', (err) => {
+    if (updateInstallStarted) {
+      updateInstallStarted = false;
+      isQuitting = false;
+    }
     ulog(`Error: ${err.message}\n${err.stack ?? ''}`);
     sendUpdateStatus('error', { message: err.message });
   });
@@ -102,16 +107,15 @@ function setupAutoUpdater(): void {
   });
 
   ipcMain.on('update-install', () => {
+    if (updateInstallStarted) {
+      ulog('Install already in progress, ignoring duplicate request');
+      return;
+    }
+    updateInstallStarted = true;
     ulog('Install requested, calling quitAndInstall...');
     isQuitting = true;
+    sendUpdateStatus('installing');
     autoUpdater.quitAndInstall();
-    // Safety net: if quitAndInstall didn't trigger quit within 5s
-    // (e.g. Squirrel deadlock), force restart the app
-    setTimeout(() => {
-      ulog('quitAndInstall did not quit within 5s, forcing restart');
-      app.relaunch();
-      app.exit(0);
-    }, 5000);
   });
 
   // Check for updates 10s after launch, then every 30 minutes

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, shell, ipcRenderer } from 'electron';
+import { contextBridge, shell, ipcRenderer, webUtils } from 'electron';
 
 // Listen for gateway errors from main process (gateway failed to start)
 ipcRenderer.on('gateway-error', (_event, payload: { error: string; logs: string }) => {
@@ -7,6 +7,11 @@ ipcRenderer.on('gateway-error', (_event, payload: { error: string; logs: string 
 
 const electronAPI = {
   platform: process.platform,
+  // Electron 32+ removed File.path, so a file dropped from Finder can only be
+  // resolved to a real path through webUtils.
+  getPathForFile: (file: File): string => {
+    try { return webUtils.getPathForFile(file); } catch { return ''; }
+  },
   appVersion: (() => { try { return require('electron').app?.getVersion?.() || process.env.npm_package_version || '0.0.0'; } catch { return '0.0.0'; } })(),
   openExternal: (url: string) => shell.openExternal(url),
   dockBounce: (type: 'critical' | 'informational') => ipcRenderer.send('dock-bounce', type),

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dorabot-desktop",
-  "version": "0.2.95",
+  "version": "0.2.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dorabot-desktop",
-      "version": "0.2.95",
+      "version": "0.2.97",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@monaco-editor/react": "4.7.0",
@@ -53,6 +53,7 @@
         "@electron-toolkit/utils": "4.0.0",
         "@electron/notarize": "3.1.1",
         "@tailwindcss/vite": "4.1.18",
+        "@testing-library/react": "16.3.2",
         "@types/canvas-confetti": "1.9.0",
         "@types/react": "19.2.13",
         "@types/react-dom": "19.2.3",
@@ -63,11 +64,34 @@
         "electron": "40.8.5",
         "electron-builder": "26.15.3",
         "electron-vite": "5.0.0",
+        "jsdom": "25.0.1",
         "tailwind-merge": "3.4.0",
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3",
-        "vite": "6.4.3"
+        "vite": "6.4.3",
+        "vitest": "3.2.7"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -319,6 +343,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -365,6 +399,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -4024,6 +4173,55 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.20.4",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.4.tgz",
@@ -4563,6 +4761,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4628,6 +4834,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -4636,6 +4853,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/diff": {
       "version": "7.0.2",
@@ -4832,6 +5056,121 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -5299,6 +5638,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/asn1js": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
@@ -5312,6 +5662,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -5740,6 +6100,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -5807,6 +6184,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -6067,11 +6454,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.19",
@@ -6095,6 +6517,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -6136,6 +6565,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defer-to-connect": {
@@ -6343,6 +6782,14 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.2",
@@ -6824,6 +7271,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -6935,6 +7389,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -6953,6 +7417,16 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -7583,6 +8057,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7640,6 +8127,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -7757,6 +8257,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7840,6 +8347,60 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/jsesc": {
@@ -8418,6 +8979,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -8445,6 +9013,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -9772,6 +10351,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9855,6 +10441,32 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9872,6 +10484,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pdfjs-dist": {
@@ -10031,6 +10660,36 @@
       "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proc-log": {
@@ -10301,6 +10960,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -10449,6 +11118,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10875,6 +11552,13 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10893,6 +11577,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -10996,6 +11687,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11088,6 +11786,13 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -11102,6 +11807,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -11155,6 +11867,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -11198,6 +11930,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -11370,6 +12109,20 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11385,6 +12138,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tiptap-markdown": {
@@ -11427,6 +12210,26 @@
       "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -11444,6 +12247,32 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/traverse": {
@@ -11903,11 +12732,120 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -11932,6 +12870,54 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -11946,6 +12932,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -11991,6 +12994,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xmlbuilder": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorabot-desktop",
-  "version": "0.2.96",
+  "version": "0.2.97",
   "description": "Desktop control center for dorabot",
   "main": "out/main/main.js",
   "scripts": {
@@ -14,7 +14,8 @@
     "verify-sig": "APP=$(find release -maxdepth 2 -name 'dorabot.app' -type d | head -1) && SIG=$(codesign -d --verbose=2 \"$APP\" 2>&1) && if echo \"$SIG\" | grep -q 'Signature=adhoc'; then echo '\\033[33m⚠ WARNING: Ad-hoc signed (no certificate). Auto-updates will NOT work.\\033[0m' && echo 'Set CSC_LINK and CSC_KEY_PASSWORD to sign properly.' && echo 'Or install from GitHub release: gh release download --pattern *.dmg'; fi && codesign --verify --deep --strict \"$APP\" && echo 'Signature verified.'",
     "make-dmg": "APP=$(find release -maxdepth 2 -name 'dorabot.app' -type d | head -1) && VER=$(node -p \"require('./package.json').version\") && DMG=\"release/dorabot-${VER}-arm64.dmg\" && rm -f \"$DMG\" && hdiutil create -volname dorabot -srcfolder \"$APP\" -ov -format UDZO \"$DMG\" && echo \"Created $DMG\"",
     "install-app": "APP=$(find release -maxdepth 2 -name 'dorabot.app' -type d | head -1) && rm -rf /Applications/dorabot.app && cp -R \"$APP\" /Applications/ && echo \"Installed $APP to /Applications/\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -62,6 +63,7 @@
     "@electron-toolkit/utils": "4.0.0",
     "@electron/notarize": "3.1.1",
     "@tailwindcss/vite": "4.1.18",
+    "@testing-library/react": "16.3.2",
     "@types/canvas-confetti": "1.9.0",
     "@types/react": "19.2.13",
     "@types/react-dom": "19.2.3",
@@ -72,10 +74,12 @@
     "electron": "40.8.5",
     "electron-builder": "26.15.3",
     "electron-vite": "5.0.0",
+    "jsdom": "25.0.1",
     "tailwind-merge": "3.4.0",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3",
-    "vite": "6.4.3"
+    "vite": "6.4.3",
+    "vitest": "3.2.7"
   },
   "overrides": {
     "dompurify": "3.3.2",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -34,7 +34,7 @@ import { ToastContainer } from './components/ToastContainer';
 
 type SessionFilter = 'all' | 'desktop' | 'telegram' | 'whatsapp';
 type UpdateState = {
-  status: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'error';
+  status: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'error';
   version?: string;
   percent?: number;
   message?: string;
@@ -334,6 +334,9 @@ export default function App() {
           break;
         case 'downloaded':
           setUpdateState({ status: 'downloaded', version: status.version });
+          break;
+        case 'installing':
+          setUpdateState(prev => ({ ...prev, status: 'installing' }));
           break;
         case 'error':
           setUpdateState({ status: 'error', message: status.message });
@@ -1249,6 +1252,12 @@ export default function App() {
           >
             Later
           </button>
+        </div>
+      )}
+      {updateState.status === 'installing' && (
+        <div className="shrink-0 px-4 py-1.5 bg-success/10 border-b border-success/20 flex items-center gap-2 text-xs">
+          <Loader2 className="w-3 h-3 animate-spin text-success" />
+          <span className="text-success">Restarting to install update...</span>
         </div>
       )}
       {updateState.status === 'error' && (

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -221,6 +221,15 @@ export default function App() {
   const [showFiles, setShowFiles] = useState(() => localStorage.getItem('dorabot:showFiles') === 'true');
   const [sidebarView, setSidebarView] = useState<'files' | 'git' | 'history'>(() => (localStorage.getItem('dorabot:sidebarView') as 'files' | 'git' | 'history') || 'files');
   const filesPanelSize = useRef(localStorage.getItem('dorabot:filesPanelSize') || '30%');
+  // defaultSize must be constant. filesPanelSize is mutated by onResize, so
+  // reading it every render fed a slightly different percentage back into the
+  // panel, which nudged it, which fired onResize again: the sidebar drifted on
+  // its own on any unrelated re-render. Freeze the mount-time value.
+  const filesPanelDefault = useRef(
+    (localStorage.getItem('dorabot:showFiles') === 'true')
+      ? (localStorage.getItem('dorabot:filesPanelSize') || '30%')
+      : '0%',
+  );
   const filesPanelRef = useRef<PanelImperativeHandle | null>(null);
   const fileExplorerStateRef = useRef<{ viewRoot: string; expanded: string[]; selectedPath: string | null }>(
     (() => {
@@ -1512,7 +1521,7 @@ export default function App() {
           panelRef={filesPanelRef}
           collapsible
           collapsedSize="0%"
-          defaultSize={showFiles ? filesPanelSize.current : "0%"}
+          defaultSize={filesPanelDefault.current}
           minSize="15%"
           maxSize="45%"
           className="overflow-hidden flex flex-col"

--- a/desktop/src/components/FileExplorer.tsx
+++ b/desktop/src/components/FileExplorer.tsx
@@ -1519,11 +1519,38 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
   const [viewRoot, setViewRoot] = useState(initialViewRoot || '');
   const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
   const [expanded, setExpanded] = useState<Set<string>>(new Set(initialExpanded || []));
+  // selectedPath is the cursor: the row the keyboard acts on and the anchor a
+  // shift-click ranges from. selection is everything highlighted. Invariant:
+  // when selectedPath is set it is also in selection.
   const [selectedPath, setSelectedPath] = useState<string | null>(initialSelectedPath ?? null);
+  const [selection, setSelection] = useState<Set<string>>(
+    () => new Set(initialSelectedPath ? [initialSelectedPath] : []),
+  );
+  // The row a shift-extension ranges from. Stays put while the cursor moves,
+  // otherwise shift+arrow would drag the anchor along and shrink the range.
+  const anchorRef = useRef<string | null>(initialSelectedPath ?? null);
+
+  // Collapse to a single row. Used by plain clicks and unshifted arrows.
+  const selectOnly = useCallback((path: string | null) => {
+    setSelectedPath(path);
+    anchorRef.current = path;
+    setSelection(path ? new Set([path]) : new Set());
+  }, []);
+
+  const toggleSelect = useCallback((path: string) => {
+    setSelection(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+    setSelectedPath(path);
+    anchorRef.current = path;
+  }, []);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [inlineInput, setInlineInput] = useState<InlineInputState>(null);
-  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
   const [fileFilter, setFileFilter] = useState('');
 
   const [gitState, setGitState] = useState<GitState | null>(null);
@@ -1725,21 +1752,31 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     focusTree();
   }, [focusTree, inlineInput, rpc, loadDir, selectedPath]);
 
+  // Deleting a row that is part of a multi-selection deletes the whole
+  // selection, the way Finder does. Right-clicking an unselected row acts on
+  // that row alone.
   const deleteItem = useCallback((path: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    setConfirmDelete(path);
-  }, []);
+    setConfirmDelete(selection.has(path) ? Array.from(selection) : [path]);
+  }, [selection]);
 
   const confirmDeleteItem = useCallback(async () => {
-    if (!confirmDelete) return;
-    try {
-      await rpc('fs.delete', { path: confirmDelete });
-      const parentPath = confirmDelete.substring(0, confirmDelete.lastIndexOf('/'));
-      loadDir(parentPath);
-      if (selectedPath === confirmDelete) setSelectedPath(null);
-    } catch (err) {
-      toast(String(err), 'error');
+    if (!confirmDelete || confirmDelete.length === 0) return;
+    const parents = new Set<string>();
+    const failures: string[] = [];
+    for (const path of confirmDelete) {
+      try {
+        await rpc('fs.delete', { path });
+        parents.add(path.substring(0, path.lastIndexOf('/')));
+      } catch (err) {
+        failures.push(`${path.substring(path.lastIndexOf('/') + 1)}: ${String(err)}`);
+      }
     }
+    parents.forEach(p => loadDir(p));
+    const gone = new Set(confirmDelete);
+    setSelection(prev => new Set(Array.from(prev).filter(p => !gone.has(p))));
+    if (selectedPath && gone.has(selectedPath)) setSelectedPath(null);
+    if (failures.length) toast(failures.join('\n'), 'error');
     setConfirmDelete(null);
   }, [confirmDelete, rpc, loadDir, selectedPath]);
 
@@ -1751,9 +1788,9 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
   }, []);
 
   const handleFileClick = useCallback((path: string) => {
-    setSelectedPath(path);
+    selectOnly(path);
     onFileClick?.(path);
-  }, [onFileClick]);
+  }, [onFileClick, selectOnly]);
 
   // ── Keyboard navigation (yazi / VS Code style) ────────────────────
   // Build flat list of visible entries for arrow key navigation
@@ -1775,6 +1812,152 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     return result;
   }, [dirs, expanded, viewRoot]);
 
+  // Shift-click / shift-arrow: select every visible row between the cursor and
+  // target inclusive. Ranges follow display order, not insertion order.
+  const extendTo = useCallback((path: string) => {
+    const visible = getVisiblePaths();
+    const anchor = anchorRef.current ?? selectedPath;
+    const anchorIdx = anchor ? visible.findIndex(v => v.path === anchor) : -1;
+    const targetIdx = visible.findIndex(v => v.path === path);
+    if (targetIdx < 0) return;
+    if (anchorIdx < 0) {
+      selectOnly(path);
+      return;
+    }
+    const [lo, hi] = anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+    setSelection(new Set(visible.slice(lo, hi + 1).map(v => v.path)));
+    // cursor moves, anchor deliberately does not
+    setSelectedPath(path);
+  }, [getVisiblePaths, selectedPath, selectOnly]);
+
+  // Everything acted on by delete/copy/drag. Falls back to the cursor so
+  // actions still work before anything has been explicitly multi-selected.
+  const actionTargets = useCallback((): string[] => {
+    if (selection.size > 0) return Array.from(selection);
+    return selectedPath ? [selectedPath] : [];
+  }, [selection, selectedPath]);
+
+  // ── Copy / paste / duplicate / drag ───────────────────────────────
+  const DRAG_MIME = 'application/x-dorabot-paths';
+  const [clipboard, setClipboard] = useState<string[]>([]);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const draggingPathsRef = useRef<string[]>([]);
+  // drop events don't reliably carry modifier state, so remember it from the
+  // last dragover, which fires continuously while hovering
+  const copyDragRef = useRef(false);
+
+  const baseName = (p: string) => p.substring(p.lastIndexOf('/') + 1);
+  const parentOf = (p: string) => p.substring(0, p.lastIndexOf('/'));
+
+  // Refuse a move/copy that would put a directory inside itself. The gateway
+  // rejects it too, this just avoids a pointless round trip and a red toast.
+  const wouldNest = (src: string, destDir: string) => destDir === src || destDir.startsWith(src + '/');
+
+  const transfer = useCallback(async (paths: string[], destDir: string, mode: 'move' | 'copy') => {
+    const touched = new Set<string>([destDir]);
+    const failures: string[] = [];
+    for (const src of paths) {
+      if (wouldNest(src, destDir)) {
+        failures.push(`${baseName(src)}: cannot go inside itself`);
+        continue;
+      }
+      if (mode === 'move' && parentOf(src) === destDir) continue; // already there
+      try {
+        if (mode === 'move') {
+          await rpc('fs.rename', { oldPath: src, newPath: destDir + '/' + baseName(src), onCollision: 'rename' });
+          touched.add(parentOf(src));
+        } else {
+          await rpc('fs.copy', { sourcePath: src, destPath: destDir + '/' + baseName(src) });
+        }
+      } catch (err) {
+        failures.push(`${baseName(src)}: ${String(err)}`);
+      }
+    }
+    touched.forEach(d => loadDir(d));
+    if (failures.length) toast(failures.join('\n'), 'error');
+  }, [rpc, loadDir]);
+
+  const copySelection = useCallback(() => {
+    const targets = actionTargets();
+    if (!targets.length) return;
+    setClipboard(targets);
+    toast(`Copied ${targets.length} item${targets.length > 1 ? 's' : ''}`, 'success');
+  }, [actionTargets]);
+
+  // Paste into the selected folder, or into the folder holding the cursor.
+  const pasteClipboard = useCallback(async () => {
+    if (!clipboard.length) return;
+    await transfer(clipboard, getCreationParentPath(), 'copy');
+  }, [clipboard, transfer, getCreationParentPath]);
+
+  const duplicateSelection = useCallback(async () => {
+    const targets = actionTargets();
+    if (!targets.length) return;
+    const failures: string[] = [];
+    for (const src of targets) {
+      try {
+        // same destination as source: the gateway appends " copy"
+        await rpc('fs.copy', { sourcePath: src, destPath: src });
+      } catch (err) {
+        failures.push(`${baseName(src)}: ${String(err)}`);
+      }
+    }
+    new Set(targets.map(parentOf)).forEach(d => loadDir(d));
+    if (failures.length) toast(failures.join('\n'), 'error');
+  }, [actionTargets, rpc, loadDir]);
+
+  const handleDragStart = useCallback((e: React.DragEvent, path: string) => {
+    // Dragging an unselected row acts on that row alone, like Finder.
+    const paths = selection.has(path) ? Array.from(selection) : [path];
+    if (!selection.has(path)) selectOnly(path);
+    draggingPathsRef.current = paths;
+    e.dataTransfer.effectAllowed = 'copyMove';
+    e.dataTransfer.setData(DRAG_MIME, JSON.stringify(paths));
+    e.dataTransfer.setData('text/plain', paths.join('\n'));
+  }, [selection, selectOnly]);
+
+  const handleDragOver = useCallback((e: React.DragEvent, path: string, isDir: boolean) => {
+    const internal = e.dataTransfer.types.includes(DRAG_MIME);
+    const external = e.dataTransfer.types.includes('Files');
+    if (!internal && !external) return;
+    const destDir = isDir ? path : parentOf(path);
+    // no drop indicator on a row being dragged, or into its own subtree
+    if (internal && draggingPathsRef.current.some(p => p === destDir || wouldNest(p, destDir))) return;
+    e.preventDefault();
+    e.stopPropagation();
+    copyDragRef.current = e.altKey;
+    e.dataTransfer.dropEffect = external ? 'copy' : (e.altKey ? 'copy' : 'move');
+    setDropTarget(isDir ? path : null);
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent, destDir: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDropTarget(null);
+
+    // From Finder: copy the files in.
+    if (e.dataTransfer.files?.length) {
+      const api = (window as unknown as { electronAPI?: { getPathForFile?: (f: File) => string } }).electronAPI;
+      const paths = Array.from(e.dataTransfer.files)
+        .map(f => api?.getPathForFile?.(f) || '')
+        .filter(Boolean);
+      if (!paths.length) {
+        toast('Could not resolve dropped file paths', 'error');
+        return;
+      }
+      await transfer(paths, destDir, 'copy');
+      return;
+    }
+
+    const raw = e.dataTransfer.getData(DRAG_MIME);
+    if (!raw) return;
+    let paths: string[] = [];
+    try { paths = JSON.parse(raw) as string[]; } catch { return; }
+    draggingPathsRef.current = [];
+    if (!paths.length) return;
+    await transfer(paths, destDir, (e.altKey || copyDragRef.current) ? 'copy' : 'move');
+  }, [transfer]);
+
   // Scroll a path's element into view (uses data-path attribute lookup via iteration, not CSS selectors)
   const scrollPathIntoView = useCallback((path: string) => {
     const container = scrollContainerRef.current;
@@ -1793,6 +1976,17 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'TEXTAREA') return;
 
     const mod = e.metaKey || e.ctrlKey;
+
+    if (mod && e.key.toLowerCase() === 'c') { e.preventDefault(); copySelection(); return; }
+    if (mod && e.key.toLowerCase() === 'v') { e.preventDefault(); void pasteClipboard(); return; }
+    if (mod && e.key.toLowerCase() === 'd') { e.preventDefault(); void duplicateSelection(); return; }
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      const targets = actionTargets();
+      if (targets.length) setConfirmDelete(targets);
+      return;
+    }
+
     if (mod && e.key.toLowerCase() === 'n') {
       e.preventDefault();
       if (e.shiftKey) createFolder();
@@ -1827,7 +2021,8 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'j': {
         e.preventDefault();
         const nextIdx = currentIdx < visible.length - 1 ? currentIdx + 1 : 0;
-        setSelectedPath(visible[nextIdx].path);
+        if (e.shiftKey) extendTo(visible[nextIdx].path);
+        else selectOnly(visible[nextIdx].path);
         scrollPathIntoView(visible[nextIdx].path);
         break;
       }
@@ -1835,7 +2030,8 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'k': {
         e.preventDefault();
         const prevIdx = currentIdx > 0 ? currentIdx - 1 : visible.length - 1;
-        setSelectedPath(visible[prevIdx].path);
+        if (e.shiftKey) extendTo(visible[prevIdx].path);
+        else selectOnly(visible[prevIdx].path);
         scrollPathIntoView(visible[prevIdx].path);
         break;
       }
@@ -1915,16 +2111,19 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
   const handleContextMenu = useCallback((e: React.MouseEvent, path: string, isDir: boolean) => {
     e.preventDefault();
     e.stopPropagation();
-    setSelectedPath(path);
+    // right-clicking inside a multi-selection keeps it; outside collapses to
+    // the clicked row
+    if (selection.has(path)) setSelectedPath(path);
+    else selectOnly(path);
     focusTree();
     setContextMenu({ x: e.clientX, y: e.clientY, path, isDir });
-  }, [focusTree]);
+  }, [focusTree, selection, selectOnly]);
 
   const handleBlankAreaContextMenu = useCallback((e: React.MouseEvent) => {
     // Only fire if the click target is the container itself (blank area)
     if (e.target === e.currentTarget || (e.target as HTMLElement).closest('[data-file-entry]') === null) {
       e.preventDefault();
-      setSelectedPath(null);
+      selectOnly(null);
       focusTree();
       setContextMenu({ x: e.clientX, y: e.clientY, path: viewRoot, isDir: true });
     }
@@ -2032,15 +2231,36 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
           key={fullPath}
           data-file-entry
           data-path={fullPath}
+          role="treeitem"
+          aria-selected={selection.has(fullPath)}
           className={cn(
             'flex items-center gap-1.5 py-0.5 px-1 rounded-sm text-[11px] cursor-pointer group transition-colors min-w-0',
             isDot && 'opacity-50',
-            selectedPath === fullPath ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
+            selection.has(fullPath) ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
+            // the cursor row is outlined so it stays visible inside a range
+            selectedPath === fullPath && selection.size > 1 && 'ring-1 ring-inset ring-primary/40',
+            dropTarget === fullPath && 'bg-primary/20 ring-1 ring-inset ring-primary',
           )}
           style={{ paddingLeft: Math.min(depth * 16, 128) + 12 }}
-          onClick={() => {
-            setSelectedPath(fullPath);
+          draggable
+          onDragStart={(e) => handleDragStart(e, fullPath)}
+          onDragOver={(e) => handleDragOver(e, fullPath, isDir)}
+          onDragLeave={() => setDropTarget(prev => (prev === fullPath ? null : prev))}
+          onDrop={(e) => handleDrop(e, isDir ? fullPath : parentPath)}
+          onDragEnd={() => { setDropTarget(null); draggingPathsRef.current = []; copyDragRef.current = false; }}
+          onClick={(e) => {
             focusTree();
+            if (e.shiftKey) {
+              e.preventDefault();
+              extendTo(fullPath);
+              return;
+            }
+            if (e.metaKey || e.ctrlKey) {
+              e.preventDefault();
+              toggleSelect(fullPath);
+              return;
+            }
+            selectOnly(fullPath);
             if (!isDir) handleFileClick(fullPath);
           }}
           onDoubleClick={isDir ? () => navigateTo(fullPath) : undefined}
@@ -2051,7 +2271,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
               className="shrink-0 rounded-sm hover:bg-secondary/60"
               onClick={(e) => {
                 e.stopPropagation();
-                setSelectedPath(fullPath);
+                selectOnly(fullPath);
                 focusTree();
                 toggleDir(fullPath);
               }}
@@ -2204,11 +2424,26 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
             treeRef.current = node;
             scrollContainerRef.current = node;
           }}
-          className="py-1 min-h-full outline-none"
+          className={cn(
+            'py-1 min-h-full outline-none',
+            dropTarget === '__root__' && 'bg-primary/10 ring-1 ring-inset ring-primary/50',
+          )}
           tabIndex={0}
           onKeyDown={handleTreeKeyDown}
           onContextMenu={handleBlankAreaContextMenu}
           onMouseDown={() => focusTree()}
+          onDragOver={(e) => {
+            const internal = e.dataTransfer.types.includes(DRAG_MIME);
+            const external = e.dataTransfer.types.includes('Files');
+            if (!internal && !external) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = external ? 'copy' : (e.altKey ? 'copy' : 'move');
+            setDropTarget('__root__');
+          }}
+          onDragLeave={(e) => {
+            if (e.currentTarget === e.target) setDropTarget(null);
+          }}
+          onDrop={(e) => { void handleDrop(e, viewRoot); }}
         >
           {viewRoot ? renderEntries(viewRoot, 0) : <div className="text-[11px] text-muted-foreground p-3">loading...</div>}
         </div>
@@ -2218,8 +2453,16 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       {confirmDelete && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setConfirmDelete(null)}>
           <div className="bg-popover border rounded-lg shadow-lg p-4 max-w-sm" onClick={e => e.stopPropagation()}>
-            <p className="text-sm mb-1">Delete this item?</p>
-            <p className="text-xs text-muted-foreground mb-3 break-all">{confirmDelete.substring(confirmDelete.lastIndexOf('/') + 1)}</p>
+            <p className="text-sm mb-1">
+              {confirmDelete.length === 1 ? 'Delete this item?' : `Delete ${confirmDelete.length} items?`}
+            </p>
+            <p className="text-xs text-muted-foreground mb-1 break-all">
+              {confirmDelete.length === 1
+                ? confirmDelete[0].substring(confirmDelete[0].lastIndexOf('/') + 1)
+                : confirmDelete.slice(0, 5).map(p => p.substring(p.lastIndexOf('/') + 1)).join(', ')
+                  + (confirmDelete.length > 5 ? ` and ${confirmDelete.length - 5} more` : '')}
+            </p>
+            <p className="text-[10px] text-muted-foreground mb-3">Moves to Trash.</p>
             <div className="flex gap-2 justify-end">
               <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setConfirmDelete(null)}>Cancel</Button>
               <Button variant="destructive" size="sm" className="h-7 text-xs" onClick={confirmDeleteItem}>Delete</Button>
@@ -2291,6 +2534,20 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { copySelection(); setContextMenu(null); }}
+              >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
+                disabled={clipboard.length === 0}
+                onClick={() => { void pasteClipboard(); setContextMenu(null); }}
+              >Paste{clipboard.length > 1 ? ` (${clipboard.length})` : ''}</button>
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { void duplicateSelection(); setContextMenu(null); }}
+              >Duplicate</button>
+              <div className="bg-border -mx-0 my-1 h-px" />
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={(e) => { renameItem(contextMenu.path, e); setContextMenu(null); }}
               >Rename</button>
               <button
@@ -2329,6 +2586,20 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={() => ctxCopyRelativePath(contextMenu.path)}
               >Copy Relative Path</button>
+              <div className="bg-border -mx-0 my-1 h-px" />
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { copySelection(); setContextMenu(null); }}
+              >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
+                disabled={clipboard.length === 0}
+                onClick={() => { void pasteClipboard(); setContextMenu(null); }}
+              >Paste{clipboard.length > 1 ? ` (${clipboard.length})` : ''}</button>
+              <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { void duplicateSelection(); setContextMenu(null); }}
+              >Duplicate</button>
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"

--- a/desktop/src/components/FileExplorer.tsx
+++ b/desktop/src/components/FileExplorer.tsx
@@ -1839,7 +1839,9 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
 
   // ── Copy / paste / duplicate / drag ───────────────────────────────
   const DRAG_MIME = 'application/x-dorabot-paths';
-  const [clipboard, setClipboard] = useState<string[]>([]);
+  // 'cut' pastes as a move. Finder has no cmd+X for files (it uses
+  // cmd+opt+V to move a copied set), VS Code does. Both are supported.
+  const [clipboard, setClipboard] = useState<{ paths: string[]; mode: 'copy' | 'cut' }>({ paths: [], mode: 'copy' });
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const draggingPathsRef = useRef<string[]>([]);
   // drop events don't reliably carry modifier state, so remember it from the
@@ -1877,17 +1879,21 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     if (failures.length) toast(failures.join('\n'), 'error');
   }, [rpc, loadDir]);
 
-  const copySelection = useCallback(() => {
+  const copySelection = useCallback((mode: 'copy' | 'cut' = 'copy') => {
     const targets = actionTargets();
     if (!targets.length) return;
-    setClipboard(targets);
-    toast(`Copied ${targets.length} item${targets.length > 1 ? 's' : ''}`, 'success');
+    setClipboard({ paths: targets, mode });
+    const verb = mode === 'cut' ? 'Cut' : 'Copied';
+    toast(`${verb} ${targets.length} item${targets.length > 1 ? 's' : ''}`, 'success');
   }, [actionTargets]);
 
   // Paste into the selected folder, or into the folder holding the cursor.
-  const pasteClipboard = useCallback(async () => {
-    if (!clipboard.length) return;
-    await transfer(clipboard, getCreationParentPath(), 'copy');
+  const pasteClipboard = useCallback(async (forceMove = false) => {
+    if (!clipboard.paths.length) return;
+    const mode = (forceMove || clipboard.mode === 'cut') ? 'move' : 'copy';
+    await transfer(clipboard.paths, getCreationParentPath(), mode);
+    // a cut is spent once pasted; a copy can be pasted repeatedly
+    if (mode === 'move') setClipboard({ paths: [], mode: 'copy' });
   }, [clipboard, transfer, getCreationParentPath]);
 
   const duplicateSelection = useCallback(async () => {
@@ -1977,11 +1983,17 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
 
     const mod = e.metaKey || e.ctrlKey;
 
-    if (mod && e.key.toLowerCase() === 'c') { e.preventDefault(); copySelection(); return; }
-    if (mod && e.key.toLowerCase() === 'v') { e.preventDefault(); void pasteClipboard(); return; }
-    if (mod && e.key.toLowerCase() === 'd') { e.preventDefault(); void duplicateSelection(); return; }
+    if (mod && e.key.toLowerCase() === 'c') { e.preventDefault();
+      e.stopPropagation(); copySelection('copy'); return; }
+    if (mod && e.key.toLowerCase() === 'x') { e.preventDefault();
+      e.stopPropagation(); copySelection('cut'); return; }
+    if (mod && e.key.toLowerCase() === 'v') { e.preventDefault();
+      e.stopPropagation(); void pasteClipboard(e.altKey); return; }
+    if (mod && e.key.toLowerCase() === 'd') { e.preventDefault();
+      e.stopPropagation(); void duplicateSelection(); return; }
     if (e.key === 'Delete' || e.key === 'Backspace') {
       e.preventDefault();
+      e.stopPropagation();
       const targets = actionTargets();
       if (targets.length) setConfirmDelete(targets);
       return;
@@ -1989,6 +2001,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
 
     if (mod && e.key.toLowerCase() === 'n') {
       e.preventDefault();
+      e.stopPropagation();
       if (e.shiftKey) createFolder();
       else createFile();
       return;
@@ -1997,6 +2010,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     // Cmd+Right: navigate into selected folder, Cmd+Left: navigate up
     if (mod && e.key === 'ArrowRight') {
       e.preventDefault();
+      e.stopPropagation();
       if (selectedPath) {
         const visible = getVisiblePaths();
         const item = visible.find(v => v.path === selectedPath);
@@ -2006,6 +2020,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     }
     if (mod && e.key === 'ArrowLeft') {
       e.preventDefault();
+      e.stopPropagation();
       const parentDir = viewRoot.substring(0, viewRoot.lastIndexOf('/'));
       if (parentDir) navigateTo(parentDir);
       return;
@@ -2020,6 +2035,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'ArrowDown':
       case 'j': {
         e.preventDefault();
+      e.stopPropagation();
         const nextIdx = currentIdx < visible.length - 1 ? currentIdx + 1 : 0;
         if (e.shiftKey) extendTo(visible[nextIdx].path);
         else selectOnly(visible[nextIdx].path);
@@ -2029,6 +2045,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'ArrowUp':
       case 'k': {
         e.preventDefault();
+      e.stopPropagation();
         const prevIdx = currentIdx > 0 ? currentIdx - 1 : visible.length - 1;
         if (e.shiftKey) extendTo(visible[prevIdx].path);
         else selectOnly(visible[prevIdx].path);
@@ -2038,6 +2055,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'ArrowRight':
       case 'l': {
         e.preventDefault();
+      e.stopPropagation();
         if (currentIdx < 0) break;
         const item = visible[currentIdx];
         if (item.isDir) {
@@ -2060,6 +2078,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       case 'ArrowLeft':
       case 'h': {
         e.preventDefault();
+      e.stopPropagation();
         if (currentIdx < 0) break;
         const item = visible[currentIdx];
         if (item.isDir && expanded.has(item.path)) {
@@ -2081,6 +2100,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       }
       case 'Enter': {
         e.preventDefault();
+      e.stopPropagation();
         if (currentIdx < 0) break;
         const item = visible[currentIdx];
         if (item.isDir) {
@@ -2236,6 +2256,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
           className={cn(
             'flex items-center gap-1.5 py-0.5 px-1 rounded-sm text-[11px] cursor-pointer group transition-colors min-w-0',
             isDot && 'opacity-50',
+            clipboard.mode === 'cut' && clipboard.paths.includes(fullPath) && 'opacity-40 italic',
             selection.has(fullPath) ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
             // the cursor row is outlined so it stays visible inside a range
             selectedPath === fullPath && selection.size > 1 && 'ring-1 ring-inset ring-primary/40',
@@ -2429,6 +2450,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
             dropTarget === '__root__' && 'bg-primary/10 ring-1 ring-inset ring-primary/50',
           )}
           tabIndex={0}
+          data-file-tree
           onKeyDown={handleTreeKeyDown}
           onContextMenu={handleBlankAreaContextMenu}
           onMouseDown={() => focusTree()}
@@ -2534,13 +2556,17 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection(); setContextMenu(null); }}
+                onClick={() => { copySelection('copy'); setContextMenu(null); }}
               >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
               <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { copySelection('cut'); setContextMenu(null); }}
+              >Cut{selection.size > 1 ? ` (${selection.size})` : ''}</button>
+              <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
-                disabled={clipboard.length === 0}
+                disabled={clipboard.paths.length === 0}
                 onClick={() => { void pasteClipboard(); setContextMenu(null); }}
-              >Paste{clipboard.length > 1 ? ` (${clipboard.length})` : ''}</button>
+              >{clipboard.mode === 'cut' ? 'Move Here' : 'Paste'}{clipboard.paths.length > 1 ? ` (${clipboard.paths.length})` : ''}</button>
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={() => { void duplicateSelection(); setContextMenu(null); }}
@@ -2589,13 +2615,17 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection(); setContextMenu(null); }}
+                onClick={() => { copySelection('copy'); setContextMenu(null); }}
               >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
               <button
+                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={() => { copySelection('cut'); setContextMenu(null); }}
+              >Cut{selection.size > 1 ? ` (${selection.size})` : ''}</button>
+              <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
-                disabled={clipboard.length === 0}
+                disabled={clipboard.paths.length === 0}
                 onClick={() => { void pasteClipboard(); setContextMenu(null); }}
-              >Paste{clipboard.length > 1 ? ` (${clipboard.length})` : ''}</button>
+              >{clipboard.mode === 'cut' ? 'Move Here' : 'Paste'}{clipboard.paths.length > 1 ? ` (${clipboard.paths.length})` : ''}</button>
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={() => { void duplicateSelection(); setContextMenu(null); }}

--- a/desktop/src/components/FileExplorer.tsx
+++ b/desktop/src/components/FileExplorer.tsx
@@ -1516,6 +1516,8 @@ function GitPanel({ rpc, gitState, onFileClick, onOpenDiff, onOpenPr, onRefresh,
 
 export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr, onFileChange, onOpenTerminal, mode = 'files', initialViewRoot, initialExpanded, initialSelectedPath, onStateChange }: Props) {
   const [homeCwd, setHomeCwd] = useState('');
+  const homeCwdRef = useRef('');
+  homeCwdRef.current = homeCwd;
   const [viewRoot, setViewRoot] = useState(initialViewRoot || '');
   const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
   const [expanded, setExpanded] = useState<Set<string>>(new Set(initialExpanded || []));
@@ -1635,6 +1637,14 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       const msg = String(err);
       // Suppress transient disconnection errors (bridge auto-reconnects)
       const isDisconnect = msg.includes('connection_lost') || msg.includes('Connection closed') || msg.includes('Not connected') || msg.includes('ws_close');
+      // A root saved from an older session may now be outside allowedPaths.
+      // Fall back to the configured root instead of showing a dead tree.
+      if (msg.includes('path not allowed') && homeCwdRef.current && path !== homeCwdRef.current) {
+        setViewRoot(homeCwdRef.current);
+        setExpanded(new Set());
+        loadDir(homeCwdRef.current);
+        return;
+      }
       setDirs(prev => {
         const next = new Map(prev);
         next.set(path, { entries: prev.get(path)?.entries || [], loading: false, ...(isDisconnect ? {} : { error: msg }) });
@@ -1922,19 +1932,20 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
     e.dataTransfer.setData('text/plain', paths.join('\n'));
   }, [selection, selectOnly]);
 
-  const handleDragOver = useCallback((e: React.DragEvent, path: string, isDir: boolean) => {
+  // path === null is the tree background, i.e. drop at the root
+  const handleDragOver = useCallback((e: React.DragEvent, path: string | null, isDir = false) => {
     const internal = e.dataTransfer.types.includes(DRAG_MIME);
     const external = e.dataTransfer.types.includes('Files');
     if (!internal && !external) return;
-    const destDir = isDir ? path : parentOf(path);
+    const destDir = path === null ? viewRoot : (isDir ? path : parentOf(path));
     // no drop indicator on a row being dragged, or into its own subtree
     if (internal && draggingPathsRef.current.some(p => p === destDir || wouldNest(p, destDir))) return;
     e.preventDefault();
     e.stopPropagation();
     copyDragRef.current = e.altKey;
     e.dataTransfer.dropEffect = external ? 'copy' : (e.altKey ? 'copy' : 'move');
-    setDropTarget(isDir ? path : null);
-  }, []);
+    setDropTarget(path === null ? '__root__' : (isDir ? path : null));
+  }, [viewRoot]);
 
   const handleDrop = useCallback(async (e: React.DragEvent, destDir: string) => {
     e.preventDefault();
@@ -2127,6 +2138,31 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
       document.removeEventListener('keydown', handleKey);
     };
   }, [contextMenu]);
+
+  // Rendered in both the folder and file context menus
+  const menuItem = 'flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors';
+  const count = (n: number) => (n > 1 ? ` (${n})` : '');
+  const clipboardMenuItems = (
+    <>
+      <div className="bg-border -mx-0 my-1 h-px" />
+      <button className={menuItem} onClick={() => { copySelection('copy'); setContextMenu(null); }}>
+        Copy{count(selection.size)}
+      </button>
+      <button className={menuItem} onClick={() => { copySelection('cut'); setContextMenu(null); }}>
+        Cut{count(selection.size)}
+      </button>
+      <button
+        className={cn(menuItem, 'disabled:opacity-40')}
+        disabled={clipboard.paths.length === 0}
+        onClick={() => { void pasteClipboard(); setContextMenu(null); }}
+      >
+        {clipboard.mode === 'cut' ? 'Move Here' : 'Paste'}{count(clipboard.paths.length)}
+      </button>
+      <button className={menuItem} onClick={() => { void duplicateSelection(); setContextMenu(null); }}>
+        Duplicate
+      </button>
+    </>
+  );
 
   const handleContextMenu = useCallback((e: React.MouseEvent, path: string, isDir: boolean) => {
     e.preventDefault();
@@ -2388,7 +2424,11 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
   const crumbs = viewRoot ? buildCrumbs(homeCwd, viewRoot) : [];
 
   return (
-    <div className="flex flex-col h-full min-h-0 border border-transparent focus-within:border-primary/60 focus-within:ring-1 focus-within:ring-primary/35" onMouseDown={(e) => {
+    <div className={cn(
+      'flex flex-col h-full min-h-0 border border-transparent focus-within:border-primary/60 focus-within:ring-1 focus-within:ring-primary/35',
+      // highlight the whole panel, not just the rows, so blank space reads as a drop target too
+      dropTarget === '__root__' && 'bg-primary/10 border-primary/60',
+    )} onMouseDown={(e) => {
       const tag = (e.target as HTMLElement).tagName;
       if (tag !== 'INPUT' && tag !== 'TEXTAREA' && tag !== 'BUTTON') focusTree();
     }}>
@@ -2439,33 +2479,25 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
           </button>
         )}
       </div>
-      <ScrollArea className="flex-1 min-h-0">
+      {/* Handlers sit on the ScrollArea, not the inner div: Radix forces its
+          wrapper to display:block with auto height, so the inner div only
+          covers its own rows and empty space below it never reaches them. */}
+      <ScrollArea className="flex-1 min-h-0"
+        onMouseDown={() => focusTree()}
+        onContextMenu={handleBlankAreaContextMenu}
+        onDragOver={(e) => handleDragOver(e, null)}
+        onDragLeave={(e) => { if (e.currentTarget === e.target) setDropTarget(null); }}
+        onDrop={(e) => { void handleDrop(e, viewRoot); }}
+      >
         <div
           ref={(node) => {
             treeRef.current = node;
             scrollContainerRef.current = node;
           }}
-          className={cn(
-            'py-1 min-h-full outline-none',
-            dropTarget === '__root__' && 'bg-primary/10 ring-1 ring-inset ring-primary/50',
-          )}
+          className="py-1 min-h-full outline-none"
           tabIndex={0}
           data-file-tree
           onKeyDown={handleTreeKeyDown}
-          onContextMenu={handleBlankAreaContextMenu}
-          onMouseDown={() => focusTree()}
-          onDragOver={(e) => {
-            const internal = e.dataTransfer.types.includes(DRAG_MIME);
-            const external = e.dataTransfer.types.includes('Files');
-            if (!internal && !external) return;
-            e.preventDefault();
-            e.dataTransfer.dropEffect = external ? 'copy' : (e.altKey ? 'copy' : 'move');
-            setDropTarget('__root__');
-          }}
-          onDragLeave={(e) => {
-            if (e.currentTarget === e.target) setDropTarget(null);
-          }}
-          onDrop={(e) => { void handleDrop(e, viewRoot); }}
         >
           {viewRoot ? renderEntries(viewRoot, 0) : <div className="text-[11px] text-muted-foreground p-3">loading...</div>}
         </div>
@@ -2553,24 +2585,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={() => ctxCopyRelativePath(contextMenu.path)}
               >Copy Relative Path</button>
-              <div className="bg-border -mx-0 my-1 h-px" />
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection('copy'); setContextMenu(null); }}
-              >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection('cut'); setContextMenu(null); }}
-              >Cut{selection.size > 1 ? ` (${selection.size})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
-                disabled={clipboard.paths.length === 0}
-                onClick={() => { void pasteClipboard(); setContextMenu(null); }}
-              >{clipboard.mode === 'cut' ? 'Move Here' : 'Paste'}{clipboard.paths.length > 1 ? ` (${clipboard.paths.length})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { void duplicateSelection(); setContextMenu(null); }}
-              >Duplicate</button>
+              {clipboardMenuItems}
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
@@ -2612,24 +2627,7 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={() => ctxCopyRelativePath(contextMenu.path)}
               >Copy Relative Path</button>
-              <div className="bg-border -mx-0 my-1 h-px" />
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection('copy'); setContextMenu(null); }}
-              >Copy{selection.size > 1 ? ` (${selection.size})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { copySelection('cut'); setContextMenu(null); }}
-              >Cut{selection.size > 1 ? ` (${selection.size})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-40"
-                disabled={clipboard.paths.length === 0}
-                onClick={() => { void pasteClipboard(); setContextMenu(null); }}
-              >{clipboard.mode === 'cut' ? 'Move Here' : 'Paste'}{clipboard.paths.length > 1 ? ` (${clipboard.paths.length})` : ''}</button>
-              <button
-                className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-                onClick={() => { void duplicateSelection(); setContextMenu(null); }}
-              >Duplicate</button>
+              {clipboardMenuItems}
               <div className="bg-border -mx-0 my-1 h-px" />
               <button
                 className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors"

--- a/desktop/src/components/file-explorer.sim.test.tsx
+++ b/desktop/src/components/file-explorer.sim.test.tsx
@@ -342,4 +342,25 @@ describe('file explorer selection + file ops', () => {
     console.log('  activeElement is tree:', document.activeElement === tree);
     expect(document.activeElement).toBe(tree);
   });
+
+  it('23. clicking empty space below the rows focuses the tree', async () => {
+    await setup();
+    const tree = document.querySelector('[data-file-tree]') as HTMLElement;
+    (document.activeElement as HTMLElement)?.blur();
+    // the scroll region, i.e. the area that includes empty space under the rows
+    const region = tree.closest('[data-slot="scroll-area"]') || tree.parentElement!.parentElement!;
+    fireEvent.mouseDown(region);
+    console.log('  focused after clicking empty region:', document.activeElement === tree);
+    expect(document.activeElement).toBe(tree);
+  });
+
+  it('24. arrows work straight after clicking empty space', async () => {
+    await setup();
+    const tree = document.querySelector('[data-file-tree]') as HTMLElement;
+    const region = tree.closest('[data-slot="scroll-area"]') || tree.parentElement!.parentElement!;
+    fireEvent.mouseDown(region);
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    console.log('  selection after ArrowDown:', selectedNames());
+    expect(selectedNames().length).toBe(1);
+  });
 });

--- a/desktop/src/components/file-explorer.sim.test.tsx
+++ b/desktop/src/components/file-explorer.sim.test.tsx
@@ -278,4 +278,60 @@ describe('file explorer selection + file ops', () => {
     console.log('  after plain down:', selectedNames());
     expect(selectedNames().length).toBe(1);
   });
+  it('18. cmd+X then cmd+V moves instead of copying', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.keyDown(row('a.ts'), { key: 'x', metaKey: true });
+    fireEvent.click(row('src'));
+    fireEvent.keyDown(row('src'), { key: 'v', metaKey: true });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    const c = mutating(calls)[0];
+    console.log('  cut+paste:', c.method, '->', c.params.newPath);
+    expect(c.method).toBe('fs.rename');
+    expect(c.params.newPath).toBe('/repo/src/a.ts');
+  });
+
+  it('19. a cut is spent after one paste, a copy is not', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.keyDown(row('a.ts'), { key: 'x', metaKey: true });
+    fireEvent.click(row('src'));
+    fireEvent.keyDown(row('src'), { key: 'v', metaKey: true });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    fireEvent.keyDown(row('src'), { key: 'v', metaKey: true });
+    await new Promise(r => setTimeout(r, 30));
+    console.log('  mutations after second paste:', mutating(calls).length);
+    expect(mutating(calls).length).toBe(1);
+  });
+
+  it('20. cmd+opt+V moves a copied selection, Finder style', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.keyDown(row('a.ts'), { key: 'c', metaKey: true });
+    fireEvent.click(row('src'));
+    fireEvent.keyDown(row('src'), { key: 'v', metaKey: true, altKey: true });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    console.log('  cmd+opt+V method:', mutating(calls)[0].method);
+    expect(mutating(calls)[0].method).toBe('fs.rename');
+  });
+
+  // The bug the isolated simulations could not see: global shortcuts live on
+  // window, so a key the tree handles must never reach them.
+  it('21. keys the tree owns do not reach window-level shortcuts', async () => {
+    await setup();
+    const seen: string[] = [];
+    const spy = (e: KeyboardEvent) => seen.push(e.key.toLowerCase());
+    window.addEventListener('keydown', spy);
+    try {
+      fireEvent.click(row('a.ts'));
+      for (const key of ['d', 'c', 'x', 'v']) {
+        fireEvent.keyDown(row('a.ts'), { key, metaKey: true });
+      }
+      fireEvent.keyDown(row('a.ts'), { key: 'Backspace' });
+      console.log('  keys that escaped to window:', seen);
+      expect(seen).toEqual([]);
+    } finally {
+      window.removeEventListener('keydown', spy);
+    }
+  });
 });

--- a/desktop/src/components/file-explorer.sim.test.tsx
+++ b/desktop/src/components/file-explorer.sim.test.tsx
@@ -334,4 +334,12 @@ describe('file explorer selection + file ops', () => {
       window.removeEventListener('keydown', spy);
     }
   });
+
+  it('22. clicking a file keeps focus in the tree', async () => {
+    await setup();
+    const tree = document.querySelector('[data-file-tree]') as HTMLElement;
+    fireEvent.click(row('a.ts'));
+    console.log('  activeElement is tree:', document.activeElement === tree);
+    expect(document.activeElement).toBe(tree);
+  });
 });

--- a/desktop/src/components/file-explorer.sim.test.tsx
+++ b/desktop/src/components/file-explorer.sim.test.tsx
@@ -1,0 +1,281 @@
+// Simulation over the real FileExplorer: selection model, clipboard, and the
+// RPCs each gesture fires. The gateway is stubbed; assertions are on the calls
+// the component actually makes.
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { FileExplorer } from './FileExplorer';
+import { TooltipProvider } from './ui/tooltip';
+
+type Entry = { name: string; type: 'file' | 'directory'; size?: number };
+
+const ROOT = '/repo';
+const TREE: Record<string, Entry[]> = {
+  '/repo': [
+    { name: 'src', type: 'directory' },
+    { name: 'a.ts', type: 'file', size: 10 },
+    { name: 'b.ts', type: 'file', size: 20 },
+    { name: 'c.ts', type: 'file', size: 30 },
+  ],
+  '/repo/src': [{ name: 'deep.ts', type: 'file', size: 5 }],
+};
+
+function makeRpc() {
+  const calls: Array<{ method: string; params: any }> = [];
+  const rpc = vi.fn(async (method: string, params?: any) => {
+    calls.push({ method, params: params ?? {} });
+    if (method === 'config.get') return { cwd: ROOT };
+    if (method === 'fs.list') return TREE[params.path] ?? [];
+    if (method === 'git.detect') return { root: null };
+    return {};
+  });
+  return { rpc, calls };
+}
+
+function mutating(calls: Array<{ method: string; params: any }>) {
+  return calls.filter(c => ['fs.copy', 'fs.rename', 'fs.delete'].includes(c.method));
+}
+
+async function setup() {
+  const { rpc, calls } = makeRpc();
+  const onFileClick = vi.fn();
+  render(
+    <TooltipProvider>
+      <FileExplorer rpc={rpc as any} connected onFileClick={onFileClick} />
+    </TooltipProvider>,
+  );
+  await waitFor(() => expect(screen.getByText('a.ts')).toBeTruthy());
+  return { rpc, calls, onFileClick };
+}
+
+// rows are the clickable divs carrying data-path
+const row = (name: string) => {
+  const el = screen.getByText(name).closest('[data-path]');
+  if (!el) throw new Error(`row not found: ${name}`);
+  return el as HTMLElement;
+};
+const isSelected = (name: string) => row(name).getAttribute('aria-selected') === 'true';
+const selectedNames = () =>
+  ['src', 'a.ts', 'b.ts', 'c.ts'].filter(n => {
+    try { return isSelected(n); } catch { return false; }
+  });
+
+// minimal DataTransfer good enough for the handlers under test
+function dt(data: Record<string, string> = {}, files: any[] = []) {
+  const store = { ...data };
+  return {
+    types: [...Object.keys(store), ...(files.length ? ['Files'] : [])],
+    files,
+    setData: (k: string, v: string) => { store[k] = v; },
+    getData: (k: string) => store[k] ?? '',
+    effectAllowed: '',
+    dropEffect: '',
+  };
+}
+
+const MIME = 'application/x-dorabot-paths';
+
+// jsdom has no DragEvent, and fireEvent falls back to a plain Event which drops
+// modifier keys. Build a MouseEvent (which carries altKey) and attach the
+// dataTransfer so option-drag exercises the real code path.
+function fireDrag(el: Element, type: string, transfer: any, altKey = false) {
+  const ev = new MouseEvent(type, { bubbles: true, cancelable: true, altKey });
+  Object.defineProperty(ev, 'dataTransfer', { value: transfer });
+  el.dispatchEvent(ev);
+}
+
+describe('file explorer selection + file ops', () => {
+  beforeEach(() => {
+    cleanup();
+    (window as any).electronAPI = { getPathForFile: (f: any) => f.__path ?? '' };
+  });
+
+  it('1. plain click selects exactly one row', async () => {
+    await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('b.ts'));
+    console.log('  selected:', selectedNames());
+    expect(selectedNames()).toEqual(['b.ts']);
+  });
+
+  it('2. cmd-click toggles rows in and out', async () => {
+    await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('c.ts'), { metaKey: true });
+    console.log('  after cmd-click:', selectedNames());
+    expect(selectedNames()).toEqual(['a.ts', 'c.ts']);
+    fireEvent.click(row('c.ts'), { metaKey: true });
+    console.log('  after toggle off:', selectedNames());
+    expect(selectedNames()).toEqual(['a.ts']);
+  });
+
+  it('3. shift-click selects the range in display order', async () => {
+    await setup();
+    fireEvent.click(row('src'));
+    fireEvent.click(row('c.ts'), { shiftKey: true });
+    console.log('  range:', selectedNames());
+    expect(selectedNames()).toEqual(['src', 'a.ts', 'b.ts', 'c.ts']);
+  });
+
+  it('4. shift-click backwards works too', async () => {
+    await setup();
+    fireEvent.click(row('c.ts'));
+    fireEvent.click(row('a.ts'), { shiftKey: true });
+    console.log('  reverse range:', selectedNames());
+    expect(selectedNames()).toEqual(['a.ts', 'b.ts', 'c.ts']);
+  });
+
+  it('5. delete acts on the whole selection and says how many', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('c.ts'), { metaKey: true });
+    fireEvent.keyDown(row('a.ts'), { key: 'Backspace' });
+    const prompt = await screen.findByText(/Delete \d+ items\?|Delete this item\?/);
+    console.log('  confirm text:', prompt.textContent);
+    expect(prompt.textContent).toBe('Delete 2 items?');
+    expect(screen.getByText('Moves to Trash.')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Delete'));
+    await waitFor(() => expect(mutating(calls).length).toBe(2));
+    console.log('  deleted:', mutating(calls).map(c => c.params.path));
+    expect(mutating(calls).every(c => c.method === 'fs.delete')).toBe(true);
+  });
+
+  it('6. single delete keeps the singular wording', async () => {
+    await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.keyDown(row('a.ts'), { key: 'Backspace' });
+    const prompt = await screen.findByText(/Delete this item\?/);
+    console.log('  confirm text:', prompt.textContent);
+    expect(prompt.textContent).toBe('Delete this item?');
+  });
+
+  it('7. cmd+D duplicates every selected row', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('b.ts'), { metaKey: true });
+    fireEvent.keyDown(row('a.ts'), { key: 'd', metaKey: true });
+    await waitFor(() => expect(mutating(calls).length).toBe(2));
+    const copies = mutating(calls);
+    console.log('  duplicate calls:', copies.map(c => `${c.params.sourcePath} -> ${c.params.destPath}`));
+    // dest === source; the gateway appends " copy"
+    expect(copies.every(c => c.method === 'fs.copy' && c.params.sourcePath === c.params.destPath)).toBe(true);
+  });
+
+  it('8. cmd+C then cmd+V copies into the selected folder', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.keyDown(row('a.ts'), { key: 'c', metaKey: true });
+    fireEvent.click(row('src'));
+    fireEvent.keyDown(row('src'), { key: 'v', metaKey: true });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    const c = mutating(calls)[0];
+    console.log('  paste:', c.method, c.params.sourcePath, '->', c.params.destPath);
+    expect(c.method).toBe('fs.copy');
+    expect(c.params.destPath).toBe('/repo/src/a.ts');
+  });
+
+  it('9. dragging a file onto a folder moves it', async () => {
+    const { calls } = await setup();
+    const transfer = dt();
+    fireEvent.dragStart(row('a.ts'), { dataTransfer: transfer });
+    console.log('  drag payload:', transfer.getData(MIME));
+    expect(JSON.parse(transfer.getData(MIME))).toEqual(['/repo/a.ts']);
+
+    fireEvent.drop(row('src'), { dataTransfer: transfer });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    const c = mutating(calls)[0];
+    console.log('  drop:', c.method, c.params);
+    expect(c.method).toBe('fs.rename');
+    expect(c.params.newPath).toBe('/repo/src/a.ts');
+    expect(c.params.onCollision).toBe('rename');
+  });
+
+  it('10. option-drag copies instead of moving', async () => {
+    const { calls } = await setup();
+    const transfer = dt();
+    fireDrag(row('a.ts'), 'dragstart', transfer);
+    fireDrag(row('src'), 'dragover', transfer, true);
+    fireDrag(row('src'), 'drop', transfer, true);
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    console.log('  option-drop method:', mutating(calls)[0].method);
+    expect(mutating(calls)[0].method).toBe('fs.copy');
+  });
+
+  it('11. dragging a multi-selection moves every item', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('b.ts'), { metaKey: true });
+    const transfer = dt();
+    fireEvent.dragStart(row('a.ts'), { dataTransfer: transfer });
+    console.log('  dragging:', JSON.parse(transfer.getData(MIME)));
+    fireEvent.drop(row('src'), { dataTransfer: transfer });
+    await waitFor(() => expect(mutating(calls).length).toBe(2));
+    console.log('  moved:', mutating(calls).map(c => c.params.newPath));
+    expect(mutating(calls).map(c => c.params.newPath).sort()).toEqual(['/repo/src/a.ts', '/repo/src/b.ts']);
+  });
+
+  it('12. dragging an unselected row acts on that row only', async () => {
+    const { calls } = await setup();
+    fireEvent.click(row('a.ts'));
+    fireEvent.click(row('b.ts'), { metaKey: true });
+    const transfer = dt();
+    fireEvent.dragStart(row('c.ts'), { dataTransfer: transfer });
+    console.log('  dragging:', JSON.parse(transfer.getData(MIME)));
+    expect(JSON.parse(transfer.getData(MIME))).toEqual(['/repo/c.ts']);
+    fireEvent.drop(row('src'), { dataTransfer: transfer });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    expect(mutating(calls)[0].params.oldPath).toBe('/repo/c.ts');
+  });
+
+  it('13. a folder cannot be dropped into itself', async () => {
+    const { calls } = await setup();
+    const transfer = dt({ [MIME]: JSON.stringify(['/repo/src']) });
+    fireEvent.drop(row('src'), { dataTransfer: transfer });
+    await new Promise(r => setTimeout(r, 30));
+    console.log('  mutating calls:', mutating(calls).length);
+    expect(mutating(calls).length).toBe(0);
+  });
+
+  it('14. dropping into the folder it already lives in is a no-op', async () => {
+    const { calls } = await setup();
+    const transfer = dt({ [MIME]: JSON.stringify(['/repo/a.ts']) });
+    // dropping a.ts onto b.ts resolves to /repo, which is already its parent
+    fireEvent.drop(row('b.ts'), { dataTransfer: transfer });
+    await new Promise(r => setTimeout(r, 30));
+    console.log('  mutating calls:', mutating(calls).length);
+    expect(mutating(calls).length).toBe(0);
+  });
+
+  it('15. dropping files from Finder copies them in', async () => {
+    const { calls } = await setup();
+    const file: any = { name: 'outside.txt', __path: '/elsewhere/outside.txt' };
+    const transfer = dt({}, [file]);
+    fireEvent.drop(row('src'), { dataTransfer: transfer });
+    await waitFor(() => expect(mutating(calls).length).toBe(1));
+    const c = mutating(calls)[0];
+    console.log('  finder drop:', c.method, c.params.sourcePath, '->', c.params.destPath);
+    expect(c.method).toBe('fs.copy');
+    expect(c.params.sourcePath).toBe('/elsewhere/outside.txt');
+    expect(c.params.destPath).toBe('/repo/src/outside.txt');
+  });
+
+  it('16. shift+arrow extends the selection', async () => {
+    await setup();
+    fireEvent.click(row('src'));
+    const tree = row('src').parentElement!;
+    fireEvent.keyDown(tree, { key: 'ArrowDown', shiftKey: true });
+    fireEvent.keyDown(tree, { key: 'ArrowDown', shiftKey: true });
+    console.log('  after shift+down x2:', selectedNames());
+    expect(selectedNames()).toEqual(['src', 'a.ts', 'b.ts']);
+  });
+
+  it('17. plain arrow collapses back to one row', async () => {
+    await setup();
+    fireEvent.click(row('src'));
+    const tree = row('src').parentElement!;
+    fireEvent.keyDown(tree, { key: 'ArrowDown', shiftKey: true });
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    console.log('  after plain down:', selectedNames());
+    expect(selectedNames().length).toBe(1);
+  });
+});

--- a/desktop/src/components/viewers/MonacoEditor.tsx
+++ b/desktop/src/components/viewers/MonacoEditor.tsx
@@ -55,6 +55,9 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
   const [monacoTheme, setMonacoTheme] = useState(theme === 'dark' ? 'vs-dark' : 'vs');
   const originalContentRef = useRef(content);
+  // Read in handleMount, which is created once
+  const readOnlyRef = useRef(readOnly);
+  readOnlyRef.current = readOnly;
   const onSaveRef = useRef(onSave);
   const onDirtyChangeRef = useRef(onDirtyChange);
   const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -214,7 +217,10 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
       }
     });
 
-    editor.focus();
+    // Only take focus when the file is actually editable. Clicking a file in
+    // the tree opens it read-only, and stealing focus there sent cmd+C/X/D to
+    // the editor instead of the explorer, which silently edited the file.
+    if (!readOnlyRef.current) editor.focus();
   }, []);
 
   const language = getMonacoLanguage(filePath);

--- a/desktop/src/components/viewers/MonacoEditor.tsx
+++ b/desktop/src/components/viewers/MonacoEditor.tsx
@@ -55,9 +55,6 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
   const [monacoTheme, setMonacoTheme] = useState(theme === 'dark' ? 'vs-dark' : 'vs');
   const originalContentRef = useRef(content);
-  // Read in handleMount, which is created once
-  const readOnlyRef = useRef(readOnly);
-  readOnlyRef.current = readOnly;
   const onSaveRef = useRef(onSave);
   const onDirtyChangeRef = useRef(onDirtyChange);
   const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -217,10 +214,12 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
       }
     });
 
-    // Only take focus when the file is actually editable. Clicking a file in
-    // the tree opens it read-only, and stealing focus there sent cmd+C/X/D to
-    // the editor instead of the explorer, which silently edited the file.
-    if (!readOnlyRef.current) editor.focus();
+    // Never take focus off the file tree. Clicking a row there opens the file
+    // here, and grabbing focus sent cmd+C/X/D to the editor instead of the
+    // explorer, silently cutting lines out of the file being viewed.
+    // Opening from anywhere else (cmd+P, tab click) still focuses normally.
+    const treeHasFocus = !!document.activeElement?.closest?.('[data-file-tree]');
+    if (!treeHasFocus) editor.focus();
   }, []);
 
   const language = getMonacoLanguage(filePath);

--- a/desktop/src/hooks/pane-roles.sim.test.tsx
+++ b/desktop/src/hooks/pane-roles.sim.test.tsx
@@ -1,0 +1,208 @@
+// throwaway simulation harness for pane role targeting.
+// exercises the real useLayout + useTabs, stubbing only the gateway.
+import { describe, it, beforeEach, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLayout } from './useLayout';
+import { useTabs, isChatTab } from './useTabs';
+
+function stubGw() {
+  let n = 0;
+  return {
+    connectionState: 'connected',
+    sessions: [],
+    sessionStates: {},
+    onFirstMessageRef: { current: null },
+    onSessionIdChangeRef: { current: null },
+    newSession: () => {
+      const chatId = `sess${++n}`;
+      return { sessionKey: `desktop:dm:${chatId}`, chatId };
+    },
+    trackSession: () => {},
+    untrackSession: () => {},
+    setActiveSession: () => {},
+    loadSessionIntoMap: () => {},
+    rpc: async () => ({}),
+  } as any;
+}
+
+function setup() {
+  const gw = stubGw();
+  return renderHook(() => {
+    const layout = useLayout();
+    const tabs = useTabs(gw, layout);
+    return { layout, tabs };
+  });
+}
+
+// renders panes as "chat|file,term" left-to-right, marking roles
+function snapshot(r: ReturnType<typeof setup>): string {
+  const { layout, tabs } = r.result.current;
+  const roles = layout.roles || {};
+  return layout.columns
+    .map(col =>
+      col.panes
+        .map(p => {
+          const kinds = p.tabIds.map(id => {
+            const t = tabs.tabs.find(x => x.id === id);
+            if (!t) return '?';
+            return isChatTab(t) ? 'chat' : t.type;
+          });
+          let tag = '';
+          if (p.id === roles.chat) tag = 'C:';
+          else if (p.id === roles.workspace) tag = 'W:';
+          return `[${tag}${kinds.join(',') || 'empty'}]`;
+        })
+        .join('/'),
+    )
+    .join(' | ');
+}
+
+function paneCount(r: ReturnType<typeof setup>) {
+  return r.result.current.layout.visibleGroups.length;
+}
+
+function chatTabCount(r: ReturnType<typeof setup>) {
+  return r.result.current.tabs.tabs.filter(isChatTab).length;
+}
+
+// node 24 ships its own localStorage which shadows jsdom's; use a plain map
+function installStorage() {
+  const map = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+      setItem: (k: string, v: string) => { map.set(k, String(v)); },
+      removeItem: (k: string) => { map.delete(k); },
+      clear: () => map.clear(),
+      key: (i: number) => [...map.keys()][i] ?? null,
+      get length() { return map.size; },
+    },
+  });
+}
+
+describe('pane role targeting', () => {
+  beforeEach(() => {
+    installStorage();
+  });
+
+  it('1. first file click splits right and leaves chat visible', () => {
+    const r = setup();
+    const before = snapshot(r);
+    act(() => { r.result.current.tabs.openFileTab('/a/agent.ts'); });
+    console.log('  start          :', before);
+    console.log('  after file     :', snapshot(r));
+    expect(paneCount(r)).toBe(2);
+    // the chat pane must still hold the chat tab
+    const { layout } = r.result.current;
+    const chatPane = layout.visibleGroups.find(p => p.id === layout.roles?.chat)!;
+    expect(chatPane.tabIds.length).toBe(1);
+  });
+
+  it('2. more files stack as tabs, no extra splits', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    act(() => { r.result.current.tabs.openFileTab('/a/two.ts'); });
+    act(() => { r.result.current.tabs.openFileTab('/a/three.ts'); });
+    console.log('  3 files        :', snapshot(r));
+    expect(paneCount(r)).toBe(2);
+  });
+
+  it('3. terminal joins the workspace pane', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    act(() => { r.result.current.tabs.openTerminalTab('/a'); });
+    console.log('  file+terminal  :', snapshot(r));
+    expect(paneCount(r)).toBe(2);
+  });
+
+  it('4. views open in workspace, not over chat', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openViewTab('settings' as any, 'Settings'); });
+    console.log('  settings       :', snapshot(r));
+    expect(paneCount(r)).toBe(2);
+  });
+
+  it('5. cmd+T new chat lands in the chat pane', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    act(() => { r.result.current.tabs.newChatTab(); });
+    console.log('  after cmd+T    :', snapshot(r));
+    const { layout } = r.result.current;
+    const chatPane = layout.visibleGroups.find(p => p.id === layout.roles?.chat)!;
+    expect(chatPane.tabIds.length).toBe(2);
+  });
+
+  it('6. closing all workspace tabs collapses, next file re-splits', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    console.log('  two panes      :', snapshot(r));
+    act(() => { r.result.current.tabs.closeTab('file:/a/one.ts'); });
+    console.log('  after close    :', snapshot(r), `(panes=${paneCount(r)})`);
+    act(() => { r.result.current.tabs.openFileTab('/a/two.ts'); });
+    console.log('  file again     :', snapshot(r));
+    expect(paneCount(r)).toBe(2);
+  });
+
+  it('7. closing all chats then cmd+T recreates a chat pane', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    const chatIds = r.result.current.tabs.tabs.filter(isChatTab).map(t => t.id);
+    act(() => { chatIds.forEach(id => r.result.current.tabs.closeTab(id)); });
+    console.log('  chats closed   :', snapshot(r), `(panes=${paneCount(r)})`);
+    act(() => { r.result.current.tabs.newChatTab(); });
+    console.log('  after cmd+T    :', snapshot(r));
+    const { layout, tabs } = r.result.current;
+    const chatPane = layout.visibleGroups.find(p => p.id === layout.roles?.chat);
+    const filePane = layout.visibleGroups.find(p => p.tabIds.includes('file:/a/one.ts'));
+    console.log('  chat separate? :', chatPane && filePane ? chatPane.id !== filePane.id : 'n/a');
+    expect(tabs.tabs.some(isChatTab)).toBe(true);
+  });
+
+  it('8. dragging a file into the chat pane keeps roles put', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    const { layout } = r.result.current;
+    const chatPaneId = layout.roles!.chat!;
+    const wsPaneId = layout.roles!.workspace!;
+    act(() => { r.result.current.layout.moveTabToGroup('file:/a/one.ts', wsPaneId, chatPaneId); });
+    console.log('  after drag     :', snapshot(r));
+    act(() => { r.result.current.tabs.openFileTab('/a/two.ts'); });
+    console.log('  next file      :', snapshot(r));
+    const after = r.result.current.layout;
+    const two = after.visibleGroups.find(p => p.tabIds.includes('file:/a/two.ts'))!;
+    console.log('  went to chat pane?', two.id === chatPaneId);
+  });
+
+  it('9. no phantom sessions appear from the split', () => {
+    const r = setup();
+    const before = chatTabCount(r);
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    const after = chatTabCount(r);
+    console.log(`  chat tabs before=${before} after=${after}`);
+    expect(after).toBe(before);
+  });
+
+  it('10. manual split then file click opens where you are looking', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    console.log('  two panes      :', snapshot(r));
+    act(() => { r.result.current.layout.addColumn(); });
+    console.log('  after cmd+D    :', snapshot(r), `(panes=${paneCount(r)})`);
+    const focused = r.result.current.layout.activeGroupId;
+    act(() => { r.result.current.tabs.openFileTab('/a/three.ts'); });
+    console.log('  file in split  :', snapshot(r));
+    const landed = r.result.current.layout.visibleGroups.find(p => p.tabIds.includes('file:/a/three.ts'))!;
+    console.log('  landed in focused pane?', landed.id === focused);
+    expect(landed.id).toBe(focused);
+  });
+
+  it('11. cmd+shift+E reset then file click re-splits', () => {
+    const r = setup();
+    act(() => { r.result.current.tabs.openFileTab('/a/one.ts'); });
+    act(() => { r.result.current.layout.resetToSingle(); });
+    console.log('  after reset    :', snapshot(r), `(panes=${paneCount(r)})`);
+    act(() => { r.result.current.tabs.openFileTab('/a/two.ts'); });
+    console.log('  file again     :', snapshot(r), `(panes=${paneCount(r)})`);
+  });
+});

--- a/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -52,6 +52,9 @@ export function useKeyboardShortcuts(actions: ShortcutActions, options: Shortcut
 
       const tag = (e.target as HTMLElement)?.tagName;
       const inInput = tag === 'INPUT' || tag === 'TEXTAREA';
+      // The file tree owns cmd+D for duplicate. Without this the tree
+      // duplicates and the pane splits on the same keystroke.
+      const inFileTree = !!(e.target as HTMLElement)?.closest?.('[data-file-tree]');
 
       // Cmd+T — new tab (not from text inputs)
       if (e.key === 't' && !e.shiftKey && !inInput) {
@@ -146,6 +149,7 @@ export function useKeyboardShortcuts(actions: ShortcutActions, options: Shortcut
 
       // Cmd+D — add column (side by side)
       if (e.key.toLowerCase() === 'd' && !e.shiftKey) {
+        if (inFileTree) return; // tree duplicates instead
         e.preventDefault();
         actions.splitHorizontal();
         return;

--- a/desktop/src/hooks/useLayout.ts
+++ b/desktop/src/hooks/useLayout.ts
@@ -14,10 +14,16 @@ export type Column = {
   sizes: number[];  // heights, sum to 100
 };
 
+// which pane a kind of tab belongs in. chat tabs never share a pane with
+// files/diffs/terminals unless the user drags them together on purpose.
+export type PaneRole = 'chat' | 'workspace';
+
 export type LayoutState = {
   columns: Column[];
   sizes: number[];  // widths, sum to 100
   activePaneId: string;
+  // optional so layouts saved before roles existed still load as-is
+  roles?: Partial<Record<PaneRole, string>>;
 };
 
 // Backwards compat: callers that used GroupId now use string
@@ -235,6 +241,40 @@ export function useLayout() {
       col.sizes = equalSizes(col.panes.length);
       const columns = prev.columns.map(c => c.id === col.id ? col : c);
       return { ...prev, columns, activePaneId: newPane.id };
+    });
+    return newPane.id;
+  }, []);
+
+  // --- Pane roles ---
+  // storage only. the policy for which role a tab wants lives in useTabs,
+  // because that's where tab types are known.
+
+  const setPaneRole = useCallback((role: PaneRole, paneId: string) => {
+    setState(prev => {
+      if (prev.roles?.[role] === paneId) return prev;
+      return { ...prev, roles: { ...(prev.roles || {}), [role]: paneId } };
+    });
+  }, []);
+
+  // creates a pane next to anchor and tags it with role. returns the new id
+  // synchronously so the caller can drop a tab into it in the same tick.
+  const createPaneForRole = useCallback((role: PaneRole, anchorPaneId: string, side: 'left' | 'right'): string => {
+    const newPane = makePane();
+    const newCol = makeColumn([newPane]);
+    setState(prev => {
+      const loc = findPaneColumn(prev, anchorPaneId);
+      const cols = [...prev.columns];
+      const insertIdx = loc
+        ? (side === 'right' ? loc.colIdx + 1 : loc.colIdx)
+        : (side === 'right' ? cols.length : 0);
+      cols.splice(insertIdx, 0, newCol);
+      return {
+        ...prev,
+        columns: cols,
+        sizes: equalSizes(cols.length),
+        activePaneId: newPane.id,
+        roles: { ...(prev.roles || {}), [role]: newPane.id },
+      };
     });
     return newPane.id;
   }, []);
@@ -511,6 +551,7 @@ export function useLayout() {
     activeGroupId,
     visibleGroups,
     isMultiPane,
+    roles: state.roles,
     // Compat (old mode-based API still works for callers that check it)
     mode: (visibleGroups.length === 1 ? 'single' : 'multi') as string,
     // Actions
@@ -519,6 +560,8 @@ export function useLayout() {
     addRow,
     addColumnAt,
     addRowAt,
+    setPaneRole,
+    createPaneForRole,
     splitHorizontal,
     splitVertical,
     splitGrid,

--- a/desktop/src/hooks/useTabs.ts
+++ b/desktop/src/hooks/useTabs.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { useGateway } from './useGateway';
-import type { useLayout, GroupId } from './useLayout';
+import type { useLayout, GroupId, PaneRole } from './useLayout';
 
 export type TabType = 'chat' | 'channels' | 'goals' | 'automation' | 'extensions' | 'agents' | 'memory' | 'research' | 'settings' | 'file' | 'diff' | 'terminal' | 'task' | 'pr';
 
@@ -171,6 +171,69 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
       return next;
     });
   }, []);
+
+  // Which pane a newly opened tab belongs in. Without this, everything falls
+  // back to activePaneId and a file click covers whatever chat you were in.
+  // Roles are stored in layout; the policy lives here because only this hook
+  // knows which tabs are chats.
+  const resolveTarget = useCallback((kind: PaneRole, explicitPaneId?: GroupId): GroupId | undefined => {
+    if (explicitPaneId) return explicitPaneId;
+
+    const panes = layout.visibleGroups;
+    if (panes.length === 0) return undefined;
+
+    const roles = layout.roles || {};
+    const alive = (id?: string) => !!id && panes.some(p => p.id === id);
+
+    const chatTabIds = new Set(tabs.filter(isChatTab).map(t => t.id));
+    const holdsChat = (p: typeof panes[number]) => p.tabIds.some(id => chatTabIds.has(id));
+    const holdsOther = (p: typeof panes[number]) => p.tabIds.some(id => !chatTabIds.has(id));
+
+    // Find where chat lives. Seed it from existing chat tabs the first time,
+    // so an initial file click can't claim the pane showing a conversation.
+    let chatId = alive(roles.chat) ? roles.chat : undefined;
+    if (!chatId) {
+      const seed = panes.find(holdsChat);
+      if (seed) {
+        chatId = seed.id;
+        layout.setPaneRole('chat', seed.id);
+      }
+    }
+
+    const wsId = alive(roles.workspace) ? roles.workspace : undefined;
+
+    if (kind === 'chat') {
+      // Chat is sticky: a new conversation never opens into an editor pane
+      // just because that's where focus happens to be.
+      if (chatId) return chatId;
+      const free = panes.find(p => p.id !== wsId && !holdsOther(p));
+      if (free) {
+        layout.setPaneRole('chat', free.id);
+        return free.id;
+      }
+      // Every pane is holding files: give chat its own rather than stacking a
+      // conversation on top of the editor.
+      return layout.createPaneForRole('chat', wsId || layout.activeGroupId, 'left');
+    }
+
+    // Workspace follows focus, so manual splits (cmd+d, cmd+g) still receive
+    // files. The only pane it refuses is the one holding chat.
+    const active = panes.find(p => p.id === layout.activeGroupId);
+    if (active && active.id !== chatId) {
+      layout.setPaneRole('workspace', active.id);
+      return active.id;
+    }
+
+    if (wsId) return wsId;
+
+    const spare = panes.find(p => p.id !== chatId);
+    if (spare) {
+      layout.setPaneRole('workspace', spare.id);
+      return spare.id;
+    }
+
+    return layout.createPaneForRole('workspace', chatId || layout.activeGroupId, 'right');
+  }, [layout, tabs]);
 
   // Migrate: if layout groups are empty but we have tabs, put them all in g0
   useEffect(() => {
@@ -398,7 +461,7 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
       return [...prev, tab];
     });
     setActiveTabId(tab.id);
-    layout.addTabToGroup(tab.id, groupId);
+    layout.addTabToGroup(tab.id, resolveTarget(isChatTab(tab) ? 'chat' : 'workspace', groupId));
 
     if (isChatTab(tab)) {
       gw.trackSession(tab.sessionKey);
@@ -573,8 +636,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
 
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [tabs, focusTab, layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [tabs, focusTab, layout, resolveTarget]);
 
   const openFileTab = useCallback((filePath: string, groupId?: GroupId) => {
     const id = `file:${filePath}`;
@@ -595,8 +658,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
 
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [tabs, focusTab, layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [tabs, focusTab, layout, resolveTarget]);
 
   const openDiffTab = useCallback((opts: {
     filePath: string;
@@ -620,8 +683,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
 
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [layout, resolveTarget]);
 
   const openTerminalTab = useCallback((cwd?: string, groupId?: GroupId) => {
     const shellId = crypto.randomUUID();
@@ -636,8 +699,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     };
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [layout, resolveTarget]);
 
   const openSessionTab = useCallback((tab: ChatTab, groupId?: GroupId) => {
     // Dedup inside updater to avoid stale-closure race on rapid double-click
@@ -658,7 +721,7 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     }
     gw.trackSession(tab.sessionKey);
     setActiveTabId(tab.id);
-    layout.addTabToGroup(tab.id, groupId);
+    layout.addTabToGroup(tab.id, resolveTarget('chat', groupId));
     gw.setActiveSession(tab.sessionKey, tab.chatId);
     // Load session history from server
     if (tab.sessionId) {
@@ -682,8 +745,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     };
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [tabs, focusTab, layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [tabs, focusTab, layout, resolveTarget]);
 
   const openPrTab = useCallback((repoRoot: string, prNumber: number, title: string, groupId?: GroupId) => {
     const id = `pr:${repoRoot}#${prNumber}`;
@@ -703,8 +766,8 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     };
     setTabs(prev => [...prev, tab]);
     setActiveTabId(id);
-    layout.addTabToGroup(id, groupId);
-  }, [tabs, focusTab, layout]);
+    layout.addTabToGroup(id, resolveTarget('workspace', groupId));
+  }, [tabs, focusTab, layout, resolveTarget]);
 
   const newChatTab = useCallback((groupId?: GroupId): { tabId: string; sessionKey: string; chatId: string } => {
     const { sessionKey, chatId } = gw.newSession();
@@ -720,9 +783,9 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     setTabs(prev => [...prev, tab]);
     setActiveTabId(tab.id);
     gw.trackSession(tab.sessionKey);
-    layout.addTabToGroup(tab.id, groupId);
+    layout.addTabToGroup(tab.id, resolveTarget('chat', groupId));
     return { tabId: tab.id, sessionKey, chatId };
-  }, [gw, layout]);
+  }, [gw, resolveTarget]);
 
   const closeOtherTabs = useCallback((tabId: string, groupId?: GroupId) => {
     const gid = groupId || layout.activeGroupId;

--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [
+      '**/node_modules/**',
+      // standalone tsx script that mirrors the layout logic instead of
+      // importing it; not a vitest suite
+      '**/useLayout.edgecases.test.ts',
+    ],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dorabot",
-  "version": "0.2.96",
+  "version": "0.2.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dorabot",
-      "version": "0.2.96",
+      "version": "0.2.97",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@anthropic-ai/sdk": "0.97.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:gateway-auth-state": "node scripts/test-gateway-auth-state.mjs",
     "test:codex-provider": "node scripts/smoke-codex-145.mjs",
     "test:claude-provider": "node scripts/smoke-claude-sdk.mjs",
-    "test:model-catalog": "node scripts/test-model-catalog.mjs"
+    "test:model-catalog": "node scripts/test-model-catalog.mjs",
+    "test:fs-ops": "tsx scripts/test-fs-ops.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.220",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorabot",
-  "version": "0.2.96",
+  "version": "0.2.97",
   "type": "module",
   "description": "Open-source personal AI agent. Persistent memory, multi-channel messaging, browser automation, and proactive goal management.",
   "main": "dist/index.js",

--- a/scripts/test-fs-ops.ts
+++ b/scripts/test-fs-ops.ts
@@ -1,0 +1,146 @@
+// Exercises the real fs-ops functions the fs.* RPCs call.
+// Run: npx tsx scripts/test-fs-ops.ts
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { uniqueDestination, isInside, moveToTrash, copyPath, movePath } from '../src/gateway/fs-ops.js';
+
+let pass = 0;
+let fail = 0;
+
+function check(name: string, got: unknown, want: unknown) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  console.log(`  ${ok ? 'ok  ' : 'FAIL'}  ${name}${ok ? '' : `\n          got  ${JSON.stringify(got)}\n          want ${JSON.stringify(want)}`}`);
+  ok ? pass++ : fail++;
+}
+
+function throws(name: string, fn: () => unknown, match: RegExp) {
+  try {
+    fn();
+    console.log(`  FAIL  ${name}\n          expected throw matching ${match}`);
+    fail++;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const ok = match.test(msg);
+    console.log(`  ${ok ? 'ok  ' : 'FAIL'}  ${name}${ok ? '' : `\n          threw ${msg}, wanted ${match}`}`);
+    ok ? pass++ : fail++;
+  }
+}
+
+const root = mkdtempSync(join(tmpdir(), 'fsops-'));
+const name = (p: string) => p.slice(p.lastIndexOf('/') + 1);
+
+console.log('\nuniqueDestination');
+{
+  const d = join(root, 'uniq');
+  mkdirSync(d);
+  check('free name untouched', name(uniqueDestination(join(d, 'a.ts'))), 'a.ts');
+
+  writeFileSync(join(d, 'a.ts'), '');
+  check('first collision', name(uniqueDestination(join(d, 'a.ts'))), 'a copy.ts');
+
+  writeFileSync(join(d, 'a copy.ts'), '');
+  check('second collision', name(uniqueDestination(join(d, 'a.ts'))), 'a copy 2.ts');
+
+  writeFileSync(join(d, 'notes'), '');
+  check('no extension', name(uniqueDestination(join(d, 'notes'))), 'notes copy');
+
+  writeFileSync(join(d, '.env'), '');
+  check('dotfile keeps leading dot', name(uniqueDestination(join(d, '.env'))), '.env copy');
+
+  writeFileSync(join(d, 'bundle.tar.gz'), '');
+  check('multi-part extension', name(uniqueDestination(join(d, 'bundle.tar.gz'))), 'bundle copy.tar.gz');
+
+  mkdirSync(join(d, 'src'));
+  check('directory collision', name(uniqueDestination(join(d, 'src'))), 'src copy');
+}
+
+console.log('\nisInside');
+{
+  check('same path', isInside('/a/b', '/a/b'), true);
+  check('nested', isInside('/a/b', '/a/b/c'), true);
+  check('sibling', isInside('/a/b', '/a/c'), false);
+  check('prefix but not nested', isInside('/a/b', '/a/bc'), false);
+}
+
+console.log('\ncopyPath');
+{
+  const d = join(root, 'copy');
+  mkdirSync(d);
+  writeFileSync(join(d, 'src.txt'), 'content');
+  const c1 = copyPath(join(d, 'src.txt'), join(d, 'dst.txt'));
+  check('copies content', readFileSync(c1, 'utf8'), 'content');
+
+  const c2 = copyPath(join(d, 'src.txt'), join(d, 'dst.txt'));
+  check('collision auto-renames', name(c2), 'dst copy.txt');
+  check('original survives collision', readFileSync(join(d, 'dst.txt'), 'utf8'), 'content');
+
+  writeFileSync(join(d, 'over.txt'), 'old');
+  copyPath(join(d, 'src.txt'), join(d, 'over.txt'), true);
+  check('overwrite replaces', readFileSync(join(d, 'over.txt'), 'utf8'), 'content');
+
+  mkdirSync(join(d, 'tree/nested'), { recursive: true });
+  writeFileSync(join(d, 'tree/nested/deep.txt'), 'deep');
+  const c3 = copyPath(join(d, 'tree'), join(d, 'tree-copy'));
+  check('recursive directory copy', readFileSync(join(c3, 'nested/deep.txt'), 'utf8'), 'deep');
+
+  throws('refuses copy into itself', () => copyPath(join(d, 'tree'), join(d, 'tree/inner')), /into itself/);
+}
+
+console.log('\nmovePath');
+{
+  const d = join(root, 'move');
+  mkdirSync(join(d, 'folder'), { recursive: true });
+  writeFileSync(join(d, 'a.txt'), 'A');
+
+  const m1 = movePath(join(d, 'a.txt'), join(d, 'folder/a.txt'));
+  check('moves into folder', readFileSync(m1, 'utf8'), 'A');
+  check('source removed', existsSync(join(d, 'a.txt')), false);
+
+  writeFileSync(join(d, 'a.txt'), 'B');
+  throws('fail policy refuses collision', () => movePath(join(d, 'a.txt'), join(d, 'folder/a.txt')), /already exists/);
+  check('failed move leaves source', readFileSync(join(d, 'a.txt'), 'utf8'), 'B');
+  check('failed move leaves target', readFileSync(join(d, 'folder/a.txt'), 'utf8'), 'A');
+
+  const m2 = movePath(join(d, 'a.txt'), join(d, 'folder/a.txt'), 'rename');
+  check('rename policy keeps both', name(m2), 'a copy.txt');
+  check('original target intact', readFileSync(join(d, 'folder/a.txt'), 'utf8'), 'A');
+
+  writeFileSync(join(d, 'a.txt'), 'C');
+  movePath(join(d, 'a.txt'), join(d, 'folder/a.txt'), 'overwrite');
+  check('overwrite policy replaces', readFileSync(join(d, 'folder/a.txt'), 'utf8'), 'C');
+
+  throws('refuses move into itself', () => movePath(join(d, 'folder'), join(d, 'folder/sub')), /into itself/);
+}
+
+console.log('\nmoveToTrash (fake trash dir, no ~/.Trash pollution)');
+{
+  const d = join(root, 'trash');
+  const fakeTrash = join(root, 'FakeTrash');
+  mkdirSync(d, { recursive: true });
+  mkdirSync(fakeTrash);
+
+  writeFileSync(join(d, 'gone.txt'), 'bye');
+  const t1 = moveToTrash(join(d, 'gone.txt'), fakeTrash);
+  check('source removed', existsSync(join(d, 'gone.txt')), false);
+  check('recoverable from trash', readFileSync(t1, 'utf8'), 'bye');
+
+  writeFileSync(join(d, 'gone.txt'), 'second');
+  const t2 = moveToTrash(join(d, 'gone.txt'), fakeTrash);
+  check('same name twice does not clobber', name(t2), 'gone copy.txt');
+  check('first trashed file intact', readFileSync(t1, 'utf8'), 'bye');
+
+  mkdirSync(join(d, 'dir/inner'), { recursive: true });
+  writeFileSync(join(d, 'dir/inner/x.txt'), 'x');
+  const t3 = moveToTrash(join(d, 'dir'), fakeTrash);
+  check('directory trashed whole', readFileSync(join(t3, 'inner/x.txt'), 'utf8'), 'x');
+
+  check('trash contents', readdirSync(fakeTrash).sort(), ['dir', 'gone copy.txt', 'gone.txt']);
+
+  throws('missing trash dir errors', () => moveToTrash(join(d, 'nope'), join(root, 'NoSuchTrash')), /does not exist/);
+}
+
+rmSync(root, { recursive: true, force: true });
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail === 0 ? 0 : 1);

--- a/src/gateway/fs-ops.ts
+++ b/src/gateway/fs-ops.ts
@@ -1,0 +1,77 @@
+// Filesystem mutations used by the fs.* RPCs. Kept out of the server switch so
+// the behaviour is reachable by tests.
+import { existsSync, renameSync, cpSync, rmSync } from 'node:fs';
+import { join, dirname, sep } from 'node:path';
+import { homedir } from 'node:os';
+
+export type CollisionPolicy = 'fail' | 'rename' | 'overwrite';
+
+// "name.ts" -> "name copy.ts" -> "name copy 2.ts". Mirrors Finder so a paste
+// or duplicate never silently clobbers. Leading dot is treated as part of the
+// stem, so ".env" becomes ".env copy" rather than " copy.env".
+export function uniqueDestination(dest: string): string {
+  if (!existsSync(dest)) return dest;
+  const dir = dirname(dest);
+  const base = dest.slice(dir.length + 1);
+  const dot = base.indexOf('.', base.startsWith('.') ? 1 : 0);
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  const ext = dot > 0 ? base.slice(dot) : '';
+  for (let n = 1; n < 1000; n++) {
+    const suffix = n === 1 ? ' copy' : ` copy ${n}`;
+    const candidate = join(dir, `${stem}${suffix}${ext}`);
+    if (!existsSync(candidate)) return candidate;
+  }
+  throw new Error('could not find a free name');
+}
+
+// True when dest sits inside src, which would recurse forever on copy and
+// orphan the subtree on move.
+export function isInside(src: string, dest: string): boolean {
+  return dest === src || dest.startsWith(src + sep);
+}
+
+// Deletes go to ~/.Trash so they stay recoverable.
+//
+// Deliberately NOT Finder automation ("tell application Finder to delete"):
+// it needs an Automation TCC grant and blocks for minutes on the permission
+// prompt, which freezes the delete. Measured at >120s before being killed.
+// A rename into ~/.Trash is instant and needs no permissions. The tradeoff is
+// losing Finder's Put Back; the file still sits in the Trash.
+//
+// Note ~/.Trash cannot be listed under TCC, but stat and rename into it work,
+// which is why uniqueDestination probes paths individually instead of reading
+// the directory.
+export function moveToTrash(target: string, trashDir = join(homedir(), '.Trash')): string {
+  if (!existsSync(trashDir)) throw new Error(`trash directory does not exist: ${trashDir}`);
+  const name = target.slice(dirname(target).length + 1);
+  const dest = uniqueDestination(join(trashDir, name));
+  try {
+    renameSync(target, dest);
+  } catch (err) {
+    // rename cannot cross devices
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    cpSync(target, dest, { recursive: true });
+    rmSync(target, { recursive: true, force: true });
+  }
+  return dest;
+}
+
+export function copyPath(src: string, dest: string, overwrite = false): string {
+  if (isInside(src, dest)) throw new Error('cannot copy a directory into itself');
+  const final = overwrite ? dest : uniqueDestination(dest);
+  cpSync(src, final, { recursive: true, errorOnExist: false });
+  return final;
+}
+
+export function movePath(src: string, dest: string, onCollision: CollisionPolicy = 'fail'): string {
+  if (isInside(src, dest)) throw new Error('cannot move a directory into itself');
+  let target = dest;
+  if (existsSync(dest)) {
+    // renameSync clobbers an existing file without warning, so a drag onto a
+    // name that already exists has to be resolved explicitly.
+    if (onCollision === 'fail') throw new Error(`already exists: ${dest}`);
+    if (onCollision === 'rename') target = uniqueDestination(dest);
+  }
+  renameSync(src, target);
+  return target;
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -20,6 +20,7 @@ const resolve = (p: string, base?: string) => {
   const expanded = p.startsWith('~') ? p.replace('~', homedir()) : p;
   return pathResolve(base || process.cwd(), expanded);
 };
+import { moveToTrash, copyPath, movePath, isInside } from './fs-ops.js';
 import type { Config } from '../config.js';
 import { isPathAllowed, saveConfig, ALWAYS_DENIED, type SecurityConfig, type ToolPolicyConfig } from '../config.js';
 import type { WsMessage, WsResponse, WsEvent, GatewayContext } from './types.js';
@@ -79,6 +80,7 @@ import {
 function macNotify(_title: string, _body: string) {
   // no-op: desktop picks up broadcast events and shows toasts/native notifications
 }
+
 
 const MARKETPLACE_REPO = 'openai/skills';
 const MARKETPLACE_PATH = 'skills/.curated';
@@ -5433,8 +5435,34 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
             return { id, error: `path not allowed: ${resolved}` };
           }
           try {
-            rmSync(resolved, { recursive: true, force: true });
-            return { id, result: { deleted: resolved } };
+            // Recoverable by default. Callers that really want it gone pass
+            // permanent, otherwise this goes to the Trash with Put Back intact.
+            if (params?.permanent === true) {
+              rmSync(resolved, { recursive: true, force: true });
+              return { id, result: { deleted: resolved, permanent: true } };
+            }
+            await moveToTrash(resolved);
+            return { id, result: { deleted: resolved, trashed: true } };
+          } catch (err) {
+            return { id, error: err instanceof Error ? err.message : String(err) };
+          }
+        }
+
+        case 'fs.copy': {
+          const sourcePath = params?.sourcePath as string;
+          const destPath = params?.destPath as string;
+          if (!sourcePath || !destPath) return { id, error: 'sourcePath and destPath required' };
+          const resolvedSrc = resolve(sourcePath, config.cwd || homedir());
+          const resolvedDest = resolve(destPath, config.cwd || homedir());
+          if (!isPathAllowed(resolvedSrc, config) || !isPathAllowed(resolvedDest, config)) {
+            return { id, error: 'path not allowed' };
+          }
+          if (isInside(resolvedSrc, resolvedDest)) {
+            return { id, error: 'cannot copy a directory into itself' };
+          }
+          try {
+            const final = copyPath(resolvedSrc, resolvedDest, params?.overwrite === true);
+            return { id, result: { sourcePath: resolvedSrc, destPath: final } };
           } catch (err) {
             return { id, error: err instanceof Error ? err.message : String(err) };
           }
@@ -5450,8 +5478,12 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
             return { id, error: `path not allowed` };
           }
           try {
-            renameSync(resolvedOld, resolvedNew);
-            return { id, result: { oldPath: resolvedOld, newPath: resolvedNew } };
+            const target = movePath(
+              resolvedOld,
+              resolvedNew,
+              (params?.onCollision as 'fail' | 'rename' | 'overwrite') || 'fail',
+            );
+            return { id, result: { oldPath: resolvedOld, newPath: target } };
           } catch (err) {
             return { id, error: err instanceof Error ? err.message : String(err) };
           }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -131,6 +131,7 @@ export type RpcMethod =
   | 'fs.mkdir'
   | 'fs.delete'
   | 'fs.rename'
+  | 'fs.copy'
   | 'fs.watch.start'
   | 'fs.watch.stop'
   | 'agent.run_background'


### PR DESCRIPTION
## What changed

- pre-create exactly one draft GitHub release before electron-builder starts publishing
- configure electron-builder to reuse that draft instead of racing to create a public release
- remove every stale or duplicate release record for the tag before a retry
- verify the built app and the app extracted from the updater ZIP with deep strict code-signature checks
- verify the ZIP SHA-512 against `latest-mac.yml`
- reconcile every generated updater asset with the draft and assert that exactly one release record exists
- upload DMG and ZIP recovery artifacts before publishing
- publish only after all asset checks pass, then verify every public download URL
- ignore duplicate update-install requests
- remove the forced five-second relaunch that could restart the old bundle while ShipIt was still installing
- show a non-clickable installing state after restart is requested

## Why

v0.2.96 produced two GitHub release records with the same tag. Parallel electron-builder publishers both observed that no release existed and each created one. The manifest, DMG, blockmaps, and ZIP were split between those records, so the manifest referenced a ZIP that was absent from the release used by the public tag URL and electron-updater received a 404.

After the exact ZIP was recovered from Actions and its SHA-512 was verified, updater logs exposed a separate restart loop. The app called `quitAndInstall()`, accepted a duplicate install request, then forcibly called `app.relaunch()` and `app.exit(0)` five seconds later. ShipIt was still staging the update, so the old app could relaunch and download the same version again.

The new flow uses one pre-created draft as the synchronization point. Nothing becomes public until the updater archive, signature, manifest, release cardinality, release assets, and backup artifacts all pass.

## Incident containment

- recovered the exact 401,208,411-byte ZIP from workflow run 30177626147
- verified SHA-256 `ae0b2ab020fbcfcd94b4f70bb1407ce87a7ba3ff52e2602b7189ef1fedfa3a98`
- confirmed the manifest SHA-512 matches the recovered ZIP
- moved both duplicate v0.2.96 release records back to draft
- confirmed the public latest release is now v0.2.93, so other installs are no longer offered v0.2.96
- confirmed the affected local install eventually completed v0.2.96 and now reports up to date

## Validation

- parsed `.github/workflows/build.yml` and `desktop/electron-builder.yml` as YAML
- syntax-checked every workflow shell block with `bash -n`
- `git diff --check`
- backend `npm run typecheck`
- desktop `npm -C desktop run typecheck`
- inspected electron-publisher behavior and confirmed an existing matching draft is reused
- verified the public latest release is v0.2.93 after containment
