### PR TITLE
fix(db): stop rebuilding the FTS index on every start, and page the rebuild

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -257,53 +257,78 @@ export function backfillFtsIndex(): void {
   const currentVersion = versionRow ? parseInt(versionRow.value, 10) : 0;
   const needsRebuild = currentVersion < FTS_VERSION;
 
-  const sample = d.prepare("SELECT text_content FROM messages_fts LIMIT 1").get() as { text_content: string | null } | undefined;
+  // messages_fts is a contentless FTS5 table (content=''), so SQLite does not store the
+  // column values and reading one back always yields NULL no matter how many rows are
+  // indexed. Probing the column therefore reported "empty" on every start, forced a full
+  // rebuild each time and left the fts_version check above unreachable. Count rows.
+  const sample = d.prepare('SELECT COUNT(*) AS n FROM messages_fts').get() as { n: number } | undefined;
 
-  if (needsRebuild || !sample?.text_content) {
+  if (needsRebuild || !sample?.n) {
     // drop and recreate for clean rebuild
     d.exec('DROP TABLE IF EXISTS messages_fts');
     d.exec("CREATE VIRTUAL TABLE messages_fts USING fts5(text_content, content='', tokenize='porter unicode61')");
 
     console.error(`[db] rebuilding FTS index (v${FTS_VERSION})...`);
-    const rows = d.prepare('SELECT id, content, type FROM messages WHERE type IN (\'user\', \'assistant\') ORDER BY id').all() as { id: number; content: string; type: string }[];
-
-    const insert = d.prepare('INSERT INTO messages_fts(rowid, text_content) VALUES (?, ?)');
-    const tx = d.transaction(() => {
-      let indexed = 0;
-      for (const row of rows) {
-        const text = extractMessageText(row.content);
-        if (!text || text.length < 5) continue;
-        insert.run(row.id, text);
-        indexed++;
-      }
-      d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_version', ?)").run(String(FTS_VERSION));
-      console.error(`[db] FTS rebuild complete (v${FTS_VERSION}): ${indexed}/${rows.length} messages indexed`);
-    });
-    tx();
+    const total = indexMessagesInPages(
+      "SELECT id, content FROM messages WHERE type IN ('user', 'assistant') AND id > ? ORDER BY id LIMIT ?"
+    );
+    d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_version', ?)").run(String(FTS_VERSION));
+    console.error(`[db] FTS rebuild complete (v${FTS_VERSION}): ${total} messages indexed`);
     return;
   }
 
   // incremental: index any messages missing from FTS (only user + assistant, skip result)
-  const missing = d.prepare(`
-    SELECT m.id, m.content, m.type FROM messages m
-    WHERE m.type IN ('user', 'assistant')
-      AND m.id NOT IN (SELECT rowid FROM messages_fts)
-    ORDER BY m.id
-  `).all() as { id: number; content: string; type: string }[];
+  const indexed = indexMessagesInPages(
+    `SELECT m.id, m.content FROM messages m
+     WHERE m.type IN ('user', 'assistant')
+       AND m.id > ?
+       AND m.id NOT IN (SELECT rowid FROM messages_fts)
+     ORDER BY m.id
+     LIMIT ?`
+  );
 
-  if (missing.length === 0) return;
+  if (indexed > 0) {
+    console.error(`[db] incremental FTS backfill complete: ${indexed} messages indexed`);
+  }
+}
 
-  console.error(`[db] incremental FTS backfill: ${missing.length} messages to index...`);
+/**
+ * Index messages into messages_fts one bounded page at a time.
+ *
+ * pageSql must select id and content, take a keyset cursor as its first parameter and a
+ * page size as its second, and order by id. Paging keeps peak memory flat regardless of
+ * history size. The previous code materialised every user and assistant message in one
+ * .all(), which on a large database exhausted the V8 heap and crash-looped the gateway.
+ *
+ * This pages rather than streaming with .iterate() on purpose: better-sqlite3 refuses to
+ * run a write while an iterator is open on the same connection, throwing "This database
+ * connection is busy executing a query", so an open iterator plus batched inserts is not
+ * an option here.
+ */
+function indexMessagesInPages(pageSql: string, pageSize = 2000): number {
+  const d = getDb();
+  const page = d.prepare(pageSql);
   const insert = d.prepare('INSERT INTO messages_fts(rowid, text_content) VALUES (?, ?)');
-  const tx = d.transaction(() => {
-    let indexed = 0;
-    for (const row of missing) {
+
+  const writePage = d.transaction((rows: { id: number; content: string }[]): number => {
+    let n = 0;
+    for (const row of rows) {
       const text = extractMessageText(row.content);
       if (!text || text.length < 5) continue;
       insert.run(row.id, text);
-      indexed++;
+      n++;
     }
-    console.error(`[db] incremental FTS backfill complete: ${indexed}/${missing.length} messages indexed`);
+    return n;
   });
-  tx();
+
+  let cursor = 0;
+  let indexed = 0;
+  for (;;) {
+    const rows = page.all(cursor, pageSize) as { id: number; content: string }[];
+    if (rows.length === 0) break;
+    indexed += writePage(rows);
+    cursor = rows[rows.length - 1].id;
+    if (rows.length < pageSize) break;
+  }
+  return indexed;
 }


### PR DESCRIPTION
Closes #37.

That issue has been open since 9 July with a correct diagnosis and no fix, so here is the fix. It turned out to need one change beyond what the issue suggested, explained below.

## Two compounding bugs

**1. The "is the index already populated?" probe can never return true.**

`messages_fts` is created as `fts5(text_content, content='')`, a contentless table. SQLite stores no column values for contentless FTS5, so reading one back always returns `NULL` no matter how many rows are indexed. `!sample?.text_content` was therefore always true, the full rebuild branch ran on every launch, and the `fts_version` check directly above it never had any effect. The first thing that branch does is `DROP TABLE`, so a perfectly good index was destroyed on every start.

Reproduction, no app required:

```sql
CREATE VIRTUAL TABLE t USING fts5(text_content, content='');
INSERT INTO t(rowid, text_content) VALUES (1, 'hello world');

SELECT text_content FROM t LIMIT 1;  -- NULL, so the index "looks empty"
SELECT COUNT(*) FROM t;              -- 1
```

**2. The rebuild materialises the entire history in one `.all()`.**

Every user and assistant message, content JSON included, was loaded into a single array before indexing. On a large history that exhausts the V8 heap. Because the table was already dropped at the top of the branch, each respawn restarted from an empty index and ran out of memory again, which is the crash loop described in #37. The incremental path had the same shape.

Bug 1 is what makes it fire on every launch. Bug 2 is what turns an unnecessary rebuild into a hard crash.

## The fix

Probe `COUNT(*)`, and page both the full rebuild and the incremental backfill through one shared helper using a keyset cursor, so peak memory stays flat regardless of history size.

**One correction to the fix suggested in #37:** it proposes `.iterate()` with batched inserts, and that does not work. better-sqlite3 refuses to run a write while an iterator is open on the same connection:

```
This database connection is busy executing a query
```

I hit this on the bundled better-sqlite3 before settling on paging. Keyset pagination gives the same bounded memory without holding an iterator open, so that is what this PR does. The reasoning is left as a comment on the helper so it does not get "simplified" back into an iterator later.

## Verification

Root `npm run typecheck` is clean.

Behaviour checked against a scratch database using the same schema:

| Check | Result |
|---|---|
| 5,000 message rebuild spanning three pages | 5,000 indexed |
| `COUNT(*)` probe after rebuild | 5,000, where the old probe reports NULL |
| Non user/assistant rows excluded | 100 system rows correctly skipped |
| Second call re-indexes nothing | 0 |
| 10 newly inserted messages | picked up incrementally |
| `MATCH` queries after paged insert | return the expected rowids |
| Row deep inside the third page | still searchable |

## Impact

On the database that prompted #37 this was re-reading and re-indexing roughly 600,000 messages on every single launch. Beyond the crash, the repeated drop and rebuild of a ~1 GB index leaves a large amount of free space behind: `VACUUM` on that database reclaimed 2.6 GiB.
