### PR TITLE
fix(desktop): recover when the gateway is slow to start instead of stranding the app

### DIFF
--- a/desktop/electron/gateway-manager.ts
+++ b/desktop/electron/gateway-manager.ts
@@ -28,6 +28,8 @@ export interface GatewayManagerOptions {
   onReady?: () => void;
   onError?: (error: string) => void;
   onExit?: (code: number) => void;
+  /** Fired once when startup exceeds the soft timeout but the process is still alive. */
+  onSlowStart?: () => void;
 }
 
 export class GatewayManager {
@@ -92,12 +94,32 @@ export class GatewayManager {
     });
   }
 
-  /** Wait for gateway token and gateway Unix socket listener to become available */
-  private async waitForReady(proc: UtilityProcess | ChildProcess, timeoutMs = 20000): Promise<void> {
+  /**
+   * Wait for the gateway token and Unix socket listener to become available.
+   *
+   * A slow start is not the same as a failed start. On a large database the gateway can
+   * spend well over the soft timeout on one-off work (schema migration, search index
+   * rebuild) before it begins listening. Treating that as a failure used to strand the
+   * app: the throw propagated to start()'s catch, which scheduled a retry, but start()
+   * returns early while `this.process` is still set, so the retry was a no-op and nothing
+   * ever re-checked the socket. The gateway would come up healthy seconds later and the
+   * window stayed dead until the user quit and relaunched.
+   *
+   * So keep waiting while the process is alive, and report progress instead of failing.
+   * A genuinely dead process is still caught: the 'exit' handler clears `this.process`,
+   * which trips the identity check below and drives the existing restart path.
+   */
+  private async waitForReady(
+    proc: UtilityProcess | ChildProcess,
+    softTimeoutMs = 20000,
+    hardTimeoutMs = 600000
+  ): Promise<void> {
     const tokenPath = GATEWAY_TOKEN_PATH;
     const socketPath = GATEWAY_SOCKET_PATH;
     const startedAt = Date.now();
-    while (Date.now() - startedAt <= timeoutMs) {
+    let notifiedSlowStart = false;
+
+    for (;;) {
       // Process exited/replaced while waiting for readiness
       if (this.process !== proc) {
         throw new Error('Gateway process exited before becoming ready');
@@ -106,9 +128,21 @@ export class GatewayManager {
         const listening = await this.isGatewayListening(socketPath);
         if (listening) return;
       }
+
+      const waited = Date.now() - startedAt;
+      if (waited > hardTimeoutMs) {
+        throw new Error(
+          `Gateway did not begin listening within ${Math.round(hardTimeoutMs / 1000)}s (process still alive)`
+        );
+      }
+      if (waited > softTimeoutMs && !notifiedSlowStart) {
+        notifiedSlowStart = true;
+        console.log('[gateway-manager] Gateway is taking longer than usual to start, still waiting...');
+        this.opts.onSlowStart?.();
+      }
+
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
-    throw new Error('Gateway failed to start within timeout');
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
Found while fixing #37. No issue filed for this one.

## The problem

`waitForReady()` gives up after a fixed 20s and throws. The interesting part is what happens next.

The throw reaches `start()`'s catch block, which increments `retries` and schedules `setTimeout(() => this.start(), 1000)`. But `start()` opens with:

```ts
if (this.process) return;
```

On a readiness timeout the gateway process is **still alive**, so `this.process` is still set and the retry returns immediately without doing anything. It is a silent no-op. Nothing re-checks the socket afterwards, and because no exception is thrown the second time, the retry counter stops advancing and `onError` is never reached either.

The result is that a gateway which simply needed longer than 20s comes up healthy moments later and the desktop never notices. The window stays dead until the user quits and relaunches the whole app.

This is reachable through ordinary slow startup work: a schema migration, or a search index rebuild on a large database. Before #37 is fixed, that rebuild happens on **every** launch, so the two bugs compound into an app that cannot start at all.

## The fix

Treat "slow" and "failed" as different things.

- Keep polling while the process is alive rather than against a wall clock deadline.
- At the old 20s mark, log and fire a new optional `onSlowStart` callback once, so the UI can say startup is still in progress instead of showing nothing.
- Keep a generous hard ceiling (10 minutes) purely as a backstop against a process that is alive but permanently wedged.

Genuine failures are unaffected and still take the existing path: the `exit` handler clears `this.process`, which trips the `this.process !== proc` identity check already inside the loop, which throws and drives the established restart logic.

`onSlowStart` is optional, so no caller has to change.

## Verification

`cd desktop && npm run typecheck` reports 0 errors, identical to the `main` baseline.

## Note

Raising the 20000 constant is the obvious workaround and it does help, but it only moves the cliff. The reason the app never recovers is the no-op retry, so that is what this addresses.
