### PR TITLE
Fix seven startup, auth, filesystem and config failures that require an app restart to clear

### DIFF
--- a/desktop/electron/gateway-bridge.ts
+++ b/desktop/electron/gateway-bridge.ts
@@ -17,6 +17,14 @@ import { httpAuthHealthCheck, httpAuthStatus, isHttpAuthAvailable, type AuthStat
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const HEARTBEAT_TIMEOUT_MS = 5_000;
 
+// Reconnect pacing. Attempts stay quick for the first stretch, which covers the
+// common cases (gateway restarting after an upgrade, a brief socket drop), then
+// settle into a slow poll so a gateway that is down for hours is retried once a
+// minute instead of every few seconds. There is deliberately no attempt limit.
+const RECONNECT_FAST_ATTEMPTS = 30;
+const RECONNECT_FAST_MAX_MS = 10_000;
+const RECONNECT_SLOW_MS = 60_000;
+
 /**
  * Connection states:
  * - connecting: WebSocket handshake in progress
@@ -293,12 +301,23 @@ export class GatewayBridge {
 
   private scheduleReconnect(reason: string): void {
     if (this.manuallyClosed || this.reconnectTimer !== null) return;
-    // Stop retrying after 30 attempts (roughly 5 minutes of backoff)
-    if (this.reconnectAttempt >= 30) {
-      this.setState('disconnected', 'Connection failed after multiple attempts. Restart the app to try again.');
-      return;
+
+    // Keep retrying indefinitely. Giving up after a fixed number of attempts left
+    // the window permanently dead with "Restart the app to try again", and the
+    // situations that exhaust those attempts are the ones that recover on their
+    // own: a machine asleep overnight, a gateway restarting behind an upgrade, a
+    // long stretch where timers never fired. The gateway is a local process on a
+    // Unix socket, so once it is back the very next attempt succeeds.
+    //
+    // This is the same failure the token refresh had: a bounded retry that
+    // treated a transient outage as terminal and required a relaunch to clear.
+    const slow = this.reconnectAttempt >= RECONNECT_FAST_ATTEMPTS;
+    const base = slow
+      ? RECONNECT_SLOW_MS
+      : Math.min(1000 * (2 ** Math.min(this.reconnectAttempt, 3)), RECONNECT_FAST_MAX_MS);
+    if (slow && this.reconnectAttempt === RECONNECT_FAST_ATTEMPTS) {
+      this.log(`gateway still unreachable after ${RECONNECT_FAST_ATTEMPTS} attempts, slowing to ${RECONNECT_SLOW_MS / 1000}s polls`);
     }
-    const base = Math.min(1000 * (2 ** Math.min(this.reconnectAttempt, 3)), 10_000);
     const jitter = Math.floor(Math.random() * 250);
     const delay = base + jitter;
     this.reconnectAttempt += 1;

--- a/desktop/electron/gateway-manager.ts
+++ b/desktop/electron/gateway-manager.ts
@@ -131,8 +131,12 @@ export class GatewayManager {
 
       const waited = Date.now() - startedAt;
       if (waited > hardTimeoutMs) {
+        if (this.process === proc) this.process = null;
+        try {
+          proc.kill();
+        } catch {}
         throw new Error(
-          `Gateway did not begin listening within ${Math.round(hardTimeoutMs / 1000)}s (process still alive)`
+          `Gateway did not begin listening within ${Math.round(hardTimeoutMs / 1000)}s`
         );
       }
       if (waited > softTimeoutMs && !notifiedSlowStart) {
@@ -216,6 +220,7 @@ export class GatewayManager {
 
       proc.on('exit', (code: number | null) => {
         console.log(`[gateway-manager] Gateway exited with code ${code}`);
+        if (this.process !== proc) return;
         this.process = null;
 
         if (!this.stopping && this.retries < this.maxRetries) {

--- a/desktop/electron/gateway-manager.ts
+++ b/desktop/electron/gateway-manager.ts
@@ -28,6 +28,8 @@ export interface GatewayManagerOptions {
   onReady?: () => void;
   onError?: (error: string) => void;
   onExit?: (code: number) => void;
+  /** Fired once when startup exceeds the soft timeout but the process is still alive. */
+  onSlowStart?: () => void;
 }
 
 export class GatewayManager {
@@ -92,12 +94,32 @@ export class GatewayManager {
     });
   }
 
-  /** Wait for gateway token and gateway Unix socket listener to become available */
-  private async waitForReady(proc: UtilityProcess | ChildProcess, timeoutMs = 20000): Promise<void> {
+  /**
+   * Wait for the gateway token and Unix socket listener to become available.
+   *
+   * A slow start is not the same as a failed start. On a large database the gateway can
+   * spend well over the soft timeout on one-off work (schema migration, search index
+   * rebuild) before it begins listening. Treating that as a failure used to strand the
+   * app: the throw propagated to start()'s catch, which scheduled a retry, but start()
+   * returns early while `this.process` is still set, so the retry was a no-op and nothing
+   * ever re-checked the socket. The gateway would come up healthy seconds later and the
+   * window stayed dead until the user quit and relaunched.
+   *
+   * So keep waiting while the process is alive, and report progress instead of failing.
+   * A genuinely dead process is still caught: the 'exit' handler clears `this.process`,
+   * which trips the identity check below and drives the existing restart path.
+   */
+  private async waitForReady(
+    proc: UtilityProcess | ChildProcess,
+    softTimeoutMs = 20000,
+    hardTimeoutMs = 120000
+  ): Promise<void> {
     const tokenPath = GATEWAY_TOKEN_PATH;
     const socketPath = GATEWAY_SOCKET_PATH;
     const startedAt = Date.now();
-    while (Date.now() - startedAt <= timeoutMs) {
+    let notifiedSlowStart = false;
+
+    for (;;) {
       // Process exited/replaced while waiting for readiness
       if (this.process !== proc) {
         throw new Error('Gateway process exited before becoming ready');
@@ -106,9 +128,21 @@ export class GatewayManager {
         const listening = await this.isGatewayListening(socketPath);
         if (listening) return;
       }
+
+      const waited = Date.now() - startedAt;
+      if (waited > hardTimeoutMs) {
+        throw new Error(
+          `Gateway did not begin listening within ${Math.round(hardTimeoutMs / 1000)}s (process still alive)`
+        );
+      }
+      if (waited > softTimeoutMs && !notifiedSlowStart) {
+        notifiedSlowStart = true;
+        console.log('[gateway-manager] Gateway is taking longer than usual to start, still waiting...');
+        this.opts.onSlowStart?.();
+      }
+
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
-    throw new Error('Gateway failed to start within timeout');
   }
 
   async start(): Promise<void> {

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -306,6 +306,12 @@ app.on('ready', async () => {
       // Gateway is listening, now connect the bridge
       gatewayBridge?.connect();
     },
+    onSlowStart: () => {
+      // First launch after an upgrade can spend a while on one-off work before the
+      // gateway listens. Say so instead of leaving a silent window.
+      console.log('[main] Gateway slow to start, still waiting');
+      updateTrayTitle('starting (this can take a minute)...');
+    },
     onError: (error) => {
       console.error('[main] Gateway error:', error);
       updateTrayTitle('offline');

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, nativeImage, session, ipcMain, shell, Notification as ElectronNotification } from 'electron';
+import { app, BrowserWindow, Tray, Menu, nativeImage, session, ipcMain, shell, webContents as electronWebContents, Notification as ElectronNotification } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { is } from '@electron-toolkit/utils';
 import * as path from 'path';
@@ -19,6 +19,40 @@ function readGatewayLogs(): string {
 }
 
 let mainWindow: BrowserWindow | null = null;
+
+export const HTML_PREVIEW_PARTITION = 'htmlpreview';
+let htmlPreviewSessionReady = false;
+const htmlPreviewContents = new Set<number>();
+const htmlPreviewRemoteAllowed = new Set<number>();
+
+function setupHtmlPreviewSession() {
+  if (htmlPreviewSessionReady) return;
+  htmlPreviewSessionReady = true;
+  const previewSession = session.fromPartition(HTML_PREVIEW_PARTITION);
+  previewSession.setPermissionRequestHandler((_wc, _permission, callback) => callback(false));
+  previewSession.webRequest.onBeforeRequest((details, callback) => {
+    const url = details.url;
+    const webContentsId = details.webContentsId;
+    const isLocal = url.startsWith('file:') || url.startsWith('data:')
+      || url.startsWith('blob:') || url.startsWith('about:') || url.startsWith('devtools:');
+    if (isLocal || (webContentsId !== undefined && htmlPreviewRemoteAllowed.has(webContentsId))) {
+      callback({ cancel: false });
+      return;
+    }
+    if (webContentsId !== undefined) {
+      mainWindow?.webContents.send('html-preview:blocked', { url, webContentsId });
+    }
+    callback({ cancel: true });
+  });
+}
+
+ipcMain.handle('html-preview:set-allow-remote', (event, webContentsId: number, allow: boolean) => {
+  if (event.sender !== mainWindow?.webContents || !htmlPreviewContents.has(webContentsId)) return false;
+  if (!electronWebContents.fromId(webContentsId)) return false;
+  if (allow) htmlPreviewRemoteAllowed.add(webContentsId);
+  else htmlPreviewRemoteAllowed.delete(webContentsId);
+  return !!allow;
+});
 let tray: Tray | null = null;
 let isQuitting = false;
 let gatewayManager: GatewayManager | null = null;
@@ -171,7 +205,35 @@ function createWindow(): void {
       nodeIntegration: false,
       sandbox: false,
       backgroundThrottling: false,
+      webviewTag: true,
     },
+  });
+
+  setupHtmlPreviewSession();
+
+  mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
+    delete (webPreferences as { preload?: string }).preload;
+    webPreferences.nodeIntegration = false;
+    webPreferences.contextIsolation = true;
+    webPreferences.sandbox = true;
+    webPreferences.webSecurity = true;
+    webPreferences.javascript = false;
+    const src = String(params.src || '');
+    const onPreviewPartition = String(params.partition || '') === HTML_PREVIEW_PARTITION;
+    if (!onPreviewPartition || !src.startsWith('file:')) {
+      console.warn('[main] refused webview attach', { src: src.slice(0, 80), partition: params.partition });
+      event.preventDefault();
+    }
+  });
+
+  mainWindow.webContents.on('did-attach-webview', (_event, contents) => {
+    htmlPreviewContents.add(contents.id);
+    contents.once('destroyed', () => {
+      htmlPreviewContents.delete(contents.id);
+      htmlPreviewRemoteAllowed.delete(contents.id);
+    });
+    contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+    contents.on('will-navigate', navEvent => navEvent.preventDefault());
   });
 
   mainWindow.once('ready-to-show', () => {

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -29,6 +29,14 @@ const electronAPI = {
     ipcRenderer.on('update-status', handler);
     return () => { ipcRenderer.removeListener('update-status', handler); };
   },
+  htmlPreviewPartition: 'htmlpreview',
+  setHtmlPreviewAllowRemote: (webContentsId: number, allow: boolean): Promise<boolean> =>
+    ipcRenderer.invoke('html-preview:set-allow-remote', webContentsId, allow),
+  onHtmlPreviewBlocked: (cb: (info: { url: string; webContentsId: number }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, info: { url: string; webContentsId: number }) => cb(info);
+    ipcRenderer.on('html-preview:blocked', handler);
+    return () => { ipcRenderer.removeListener('html-preview:blocked', handler); };
+  },
   // Gateway bridge IPC (WebSocket runs in main process, renderer talks via IPC)
   gatewaySend: (data: string) => ipcRenderer.send('gateway:send', data),
   gatewayState: (): Promise<{ state: string; reconnectCount: number; connectId?: string }> => ipcRenderer.invoke('gateway:state'),

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -31,6 +31,7 @@ import {
 import { PALETTES } from './lib/palettes';
 import type { Palette as PaletteId } from './lib/palettes';
 import { ToastContainer } from './components/ToastContainer';
+import { FILE_PREVIEW_EVENT } from './lib/file-preview';
 
 type SessionFilter = 'all' | 'desktop' | 'telegram' | 'whatsapp';
 type UpdateState = {
@@ -112,7 +113,6 @@ const QUICK_OPEN_IGNORED_DIRS = new Set([
 ]);
 const QUICK_OPEN_MAX_FILES = 8000;
 const QUICK_OPEN_MAX_RESULTS = 120;
-const MARKDOWN_PREVIEW_EVENT = 'dorabot:markdown-preview';
 
 function joinPath(base: string, name: string): string {
   if (!base || base === '.') return `./${name}`;
@@ -831,10 +831,10 @@ export default function App() {
     openQuickOpen: () => openQuickOpen(),
     openGlobalSearch: () => setShowGlobalSearch(true),
     openShortcutHelp: () => setShowShortcutHelp(p => !p),
-    previewMarkdown: () => {
+    previewFile: () => {
       const tab = tabState.activeTab;
-      if (!tab || tab.type !== 'file' || !tab.filePath.toLowerCase().endsWith('.md')) return;
-      window.dispatchEvent(new CustomEvent(MARKDOWN_PREVIEW_EVENT, { detail: { filePath: tab.filePath } }));
+      if (!tab || tab.type !== 'file') return;
+      window.dispatchEvent(new CustomEvent(FILE_PREVIEW_EVENT, { detail: { filePath: tab.filePath } }));
     },
     toggleFiles: toggleFileExplorer,
     openSettings: () => handleNavClick('settings'),

--- a/desktop/src/components/EditorGroupPanel.draft.test.tsx
+++ b/desktop/src/components/EditorGroupPanel.draft.test.tsx
@@ -1,0 +1,158 @@
+import { useRef, useState } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorGroupPanel } from './EditorGroupPanel';
+import { TooltipProvider } from './ui/tooltip';
+
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({ palette: 'default-dark' }),
+}));
+
+vi.mock('./FileViewer', () => ({ FileViewer: () => null }));
+vi.mock('./viewers/DiffViewer', () => ({ DiffViewer: () => null }));
+vi.mock('./viewers/ImageDiffViewer', () => ({ ImageDiffViewer: () => null }));
+vi.mock('./TerminalView', () => ({ TerminalView: () => null }));
+
+const SESSION_KEY = 'desktop:dm:draft-test';
+const CHAT_TAB = {
+  id: 'chat:draft-test',
+  type: 'chat' as const,
+  label: 'draft test',
+  closable: true as const,
+  sessionKey: SESSION_KEY,
+  chatId: 'draft-test',
+};
+const FILE_TAB = {
+  id: 'file:draft-test',
+  type: 'file' as const,
+  label: 'draft.json',
+  closable: true as const,
+  filePath: '/tmp/draft.json',
+};
+
+function makeGateway() {
+  return {
+    sessionStates: {
+      [SESSION_KEY]: { chatItems: [], agentStatus: 'idle', pendingQuestion: null },
+    },
+    connectionState: 'connected',
+    providerInfo: { auth: { authenticated: true } },
+    gatewayError: null,
+    gatewayTelemetry: { reconnectCount: 0 },
+    pendingApprovals: [],
+    backgroundTasks: {},
+    rpc: vi.fn(async () => []),
+    getSessionModel: vi.fn(() => undefined),
+    getProviderAuth: vi.fn(async () => ({})),
+    getCodexModels: vi.fn(async () => ({ models: [] })),
+    sendMessage: vi.fn(async () => {}),
+    setProvider: vi.fn(async () => ({})),
+    setConfig: vi.fn(async () => ({})),
+    changeSessionModel: vi.fn(),
+    changeModel: vi.fn(),
+    answerQuestion: vi.fn(),
+    dismissQuestion: vi.fn(),
+    approveToolUse: vi.fn(),
+    denyToolUse: vi.fn(),
+    abortAgent: vi.fn(),
+    onShellEvent: vi.fn(),
+  };
+}
+
+function Harness() {
+  const [split, setSplit] = useState(false);
+  const [activeTabId, setActiveTabId] = useState(CHAT_TAB.id);
+  const drafts = useRef(new Map());
+  const gateway = useRef(makeGateway()).current;
+  const tabState = {
+    tabs: [CHAT_TAB, FILE_TAB],
+    unreadBySession: {},
+    dirtyTabs: new Set(),
+    closeTab: vi.fn(),
+    newChatTab: vi.fn(),
+    focusTab: vi.fn(),
+    closeOtherTabs: vi.fn(),
+    closeAllTabs: vi.fn(),
+    closeTabsToRight: vi.fn(),
+    updateTabLabel: vi.fn(),
+    openFileTab: vi.fn(),
+    openDiffTab: vi.fn(),
+    setTabDirty: vi.fn(),
+    chatDrafts: drafts.current,
+  };
+  const panel = (
+    <EditorGroupPanel
+      group={{ id: 'pane-a', tabIds: [CHAT_TAB.id, FILE_TAB.id], activeTabId }}
+      tabs={[CHAT_TAB, FILE_TAB]}
+      isActive
+      isMultiPane={split}
+      isDragging={false}
+      gateway={gateway as any}
+      tabState={tabState as any}
+      selectedChannel="whatsapp"
+      onFocusGroup={() => {}}
+      onNavigateSettings={() => {}}
+      onViewSession={() => {}}
+      onSwitchChannel={() => {}}
+      onSetupChat={() => {}}
+      onNavClick={() => {}}
+    />
+  );
+
+  return (
+    <TooltipProvider>
+      <button type="button" onClick={() => setSplit(true)}>Split</button>
+      <button type="button" onClick={() => setActiveTabId(FILE_TAB.id)}>Show file</button>
+      <button type="button" onClick={() => setActiveTabId(CHAT_TAB.id)}>Show chat</button>
+      {split ? <div>{panel}</div> : panel}
+    </TooltipProvider>
+  );
+}
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+});
+
+afterEach(cleanup);
+
+describe('chat drafts', () => {
+  it('survives the panel remount caused by adding a split', () => {
+    render(<Harness />);
+    const input = screen.getByPlaceholderText('what are we building?');
+    fireEvent.change(input, { target: { value: 'keep this draft' } });
+    expect((input as HTMLTextAreaElement).value).toBe('keep this draft');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Split' }));
+
+    expect((screen.getByPlaceholderText('what are we building?') as HTMLTextAreaElement).value).toBe('keep this draft');
+  });
+
+  it('survives switching to a non-chat tab and back', () => {
+    render(<Harness />);
+    fireEvent.change(screen.getByPlaceholderText('what are we building?'), {
+      target: { value: 'still here' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show file' }));
+    expect(screen.queryByPlaceholderText('what are we building?')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show chat' }));
+    expect((screen.getByPlaceholderText('what are we building?') as HTMLTextAreaElement).value).toBe('still here');
+  });
+
+  it('does not restore a draft after it is sent', () => {
+    render(<Harness />);
+    const input = screen.getByPlaceholderText('what are we building?');
+    fireEvent.change(input, { target: { value: 'send this' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    expect((input as HTMLTextAreaElement).value).toBe('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Split' }));
+    expect((screen.getByPlaceholderText('what are we building?') as HTMLTextAreaElement).value).toBe('');
+  });
+});

--- a/desktop/src/components/EditorGroupPanel.tsx
+++ b/desktop/src/components/EditorGroupPanel.tsx
@@ -143,6 +143,7 @@ export function EditorGroupPanel({
             agentStatus={ss.agentStatus}
             pendingQuestion={ss.pendingQuestion}
             sessionKey={activeTab.sessionKey}
+            drafts={tabState.chatDrafts}
             onNavigateSettings={onNavigateSettings}
             onOpenFile={(filePath) => tabState.openFileTab(filePath)}
             onOpenDiff={(opts) => tabState.openDiffTab(opts)}

--- a/desktop/src/components/FileExplorer.tsx
+++ b/desktop/src/components/FileExplorer.tsx
@@ -1520,6 +1520,11 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
   homeCwdRef.current = homeCwd;
   const [viewRoot, setViewRoot] = useState(initialViewRoot || '');
   const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
+  // Mirror of `dirs` for the fs.change subscription. Reading the state directly
+  // there would put it in the effect's deps and tear down and re-establish the
+  // watch every time any directory loads.
+  const dirsRef = useRef(dirs);
+  dirsRef.current = dirs;
   const [expanded, setExpanded] = useState<Set<string>>(new Set(initialExpanded || []));
   // selectedPath is the cursor: the row the keyboard acts on and the anchor a
   // shift-click ranges from. selection is everything highlighted. Invariant:
@@ -1677,9 +1682,16 @@ export function FileExplorer({ rpc, connected, onFileClick, onOpenDiff, onOpenPr
 
   useEffect(() => {
     if (!viewRoot || !connected) return;
-    rpc('fs.watch.start', { path: viewRoot }).catch(() => {});
+    // Surface a failed watch instead of swallowing it. When this silently failed
+    // the tree just stopped updating, which reads as "the explorer is broken"
+    // rather than "the watcher never started".
+    rpc('fs.watch.start', { path: viewRoot }).catch((err) => {
+      console.error('[FileExplorer] failed to start fs watch', viewRoot, err);
+    });
     const unsubscribe = onFileChange?.((changedPath) => {
-      if (changedPath === viewRoot) loadDir(viewRoot);
+      // Reload whichever directory changed, provided it is one we have loaded.
+      // Only ever reloading viewRoot left every expanded subdirectory stale.
+      if (changedPath === viewRoot || dirsRef.current.has(changedPath)) loadDir(changedPath);
     });
     return () => {
       rpc('fs.watch.stop', { path: viewRoot }).catch(() => {});

--- a/desktop/src/components/FileViewer.test.tsx
+++ b/desktop/src/components/FileViewer.test.tsx
@@ -1,0 +1,71 @@
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FILE_PREVIEW_EVENT } from '@/lib/file-preview';
+import { FileViewer } from './FileViewer';
+
+const mocks = vi.hoisted(() => ({
+  flush: vi.fn<() => Promise<void>>(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('./viewers/MonacoEditor', () => ({
+  MonacoEditor: forwardRef(function MockMonacoEditor(_props, ref) {
+    useImperativeHandle(ref, () => ({ flush: mocks.flush }));
+    return <div>editor</div>;
+  }),
+}));
+
+vi.mock('./viewers/JsonViewer', () => ({
+  JsonViewer: () => <div>json preview</div>,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError },
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  mocks.flush.mockReset();
+  mocks.flush.mockResolvedValue();
+  mocks.toastError.mockReset();
+});
+
+describe('file preview transitions', () => {
+  it('waits for the editor buffer to save before unmounting it', async () => {
+    let finishSave: (() => void) | undefined;
+    mocks.flush.mockImplementationOnce(() => new Promise<void>(resolve => {
+      finishSave = resolve;
+    }));
+    const rpc = vi.fn(async () => ({ content: '{"ready":true}' }));
+
+    render(<FileViewer filePath="/tmp/data.json" rpc={rpc} onClose={() => {}} headerless />);
+    await screen.findByText('json preview');
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await screen.findByText('editor');
+
+    window.dispatchEvent(new CustomEvent(FILE_PREVIEW_EVENT, {
+      detail: { filePath: '/tmp/data.json' },
+    }));
+
+    expect(mocks.flush).toHaveBeenCalledOnce();
+    expect(screen.getByText('editor')).toBeTruthy();
+
+    await act(async () => finishSave?.());
+    await waitFor(() => expect(screen.getByText('json preview')).toBeTruthy());
+  });
+
+  it('stays in the editor when saving fails', async () => {
+    mocks.flush.mockRejectedValueOnce(new Error('disk full'));
+    const rpc = vi.fn(async () => ({ content: '<main>hello</main>' }));
+
+    render(<FileViewer filePath="/tmp/page.html" rpc={rpc} onClose={() => {}} headerless />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await screen.findByText('editor');
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledOnce());
+    expect(screen.getByText('editor')).toBeTruthy();
+  });
+});

--- a/desktop/src/components/FileViewer.tsx
+++ b/desktop/src/components/FileViewer.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { MonacoEditor } from './viewers/MonacoEditor';
 import { MarkdownViewer } from './viewers/MarkdownViewer';
+import { HtmlViewer } from './viewers/HtmlViewer';
+import { JsonViewer } from './viewers/JsonViewer';
 const PDFViewer = lazy(() => import('./viewers/PDFViewer').then(m => ({ default: m.PDFViewer })));
 import { ExcelViewer } from './viewers/ExcelViewer';
 import { ImageViewer } from './viewers/ImageViewer';
@@ -9,8 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { X, Pencil, Eye } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-const MARKDOWN_PREVIEW_EVENT = 'dorabot:markdown-preview';
+import { FILE_PREVIEW_EVENT, supportsFilePreview } from '@/lib/file-preview';
 
 type Props = {
   filePath: string;
@@ -18,13 +19,14 @@ type Props = {
   onClose: () => void;
   headerless?: boolean;
   onDirtyChange?: (dirty: boolean) => void;
+  htmlSrcResolver?: (path: string) => string;
 };
 
-type FileType = 'code' | 'markdown' | 'pdf' | 'excel' | 'image' | 'video' | 'audio' | 'unsupported';
+type FileType = 'code' | 'markdown' | 'html' | 'json' | 'pdf' | 'excel' | 'image' | 'video' | 'audio' | 'unsupported';
 
 const CODE_EXTENSIONS = [
   'js', 'jsx', 'ts', 'tsx', 'py', 'rs', 'go', 'java', 'c', 'cpp', 'h', 'hpp',
-  'css', 'html', 'json', 'xml', 'yaml', 'yml', 'toml', 'sh', 'bash', 'zsh',
+  'css', 'xml', 'yaml', 'yml', 'toml', 'sh', 'bash', 'zsh',
   'rb', 'php', 'swift', 'kt', 'scala', 'sql', 'r', 'lua', 'vim', 'txt', 'log',
   'env', 'gitignore', 'dockerignore', 'Makefile', 'Dockerfile',
 ];
@@ -41,6 +43,8 @@ function getFileType(path: string): FileType {
   // Handle extensionless files as code (plain text fallback)
   if (!ext) return 'code';
   if (ext === 'md') return 'markdown';
+  if (ext === 'html' || ext === 'htm') return 'html';
+  if (ext === 'json') return 'json';
   if (ext === 'pdf') return 'pdf';
   if (EXCEL_EXTENSIONS.includes(ext)) return 'excel';
   if (IMAGE_EXTENSIONS.includes(ext)) return 'image';
@@ -55,16 +59,16 @@ function getFileName(path: string): string {
   return path.split('/').pop() || path;
 }
 
-export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange }: Props) {
+export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, htmlSrcResolver }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [content, setContent] = useState<string>('');
-  const [editing, setEditing] = useState(true);
+  const [editing, setEditing] = useState(() => !['html', 'json'].includes(getFileType(filePath)));
   const [dirty, setDirty] = useState(false);
   const [version, setVersion] = useState(0); // bump to force reload
   const fileType = getFileType(filePath);
   const fileName = getFileName(filePath);
-  const canEdit = fileType === 'code' || fileType === 'markdown';
+  const canEdit = fileType === 'code' || supportsFilePreview(fileType);
 
   useEffect(() => {
     if (fileType === 'unsupported') {
@@ -92,6 +96,10 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange }
         setLoading(false);
       });
   }, [filePath, rpc, fileType, version]);
+
+  useEffect(() => {
+    setEditing(!['html', 'json'].includes(getFileType(filePath)));
+  }, [filePath]);
 
   const handleSave = useCallback(async (newContent: string) => {
     await rpc('fs.write', { path: filePath, content: newContent });
@@ -136,17 +144,17 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange }
     };
   }, [filePath, rpc]);
 
-  // Cmd+Shift+V handler (dispatched by App): force markdown tabs into rendered preview mode.
+  // Cmd+Shift+V asks the active file's viewer to show its preview mode.
   useEffect(() => {
-    if (fileType !== 'markdown') return;
+    if (!supportsFilePreview(fileType)) return;
     const onPreview = (event: Event) => {
       const detail = (event as CustomEvent<{ filePath?: string }>).detail;
       if (!detail?.filePath) return;
       if (detail.filePath !== filePath) return;
       setEditing(false);
     };
-    window.addEventListener(MARKDOWN_PREVIEW_EVENT, onPreview as EventListener);
-    return () => window.removeEventListener(MARKDOWN_PREVIEW_EVENT, onPreview as EventListener);
+    window.addEventListener(FILE_PREVIEW_EVENT, onPreview as EventListener);
+    return () => window.removeEventListener(FILE_PREVIEW_EVENT, onPreview as EventListener);
   }, [filePath, fileType]);
 
   const renderViewer = () => {
@@ -189,6 +197,32 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange }
           );
         }
         return <MarkdownViewer content={content} />;
+      case 'html':
+        if (editing) {
+          return (
+            <MonacoEditor
+              content={content}
+              filePath={filePath}
+              readOnly={false}
+              onSave={handleSave}
+              onDirtyChange={handleDirtyChange}
+            />
+          );
+        }
+        return <HtmlViewer filePath={filePath} resolveSrc={htmlSrcResolver} />;
+      case 'json':
+        if (editing) {
+          return (
+            <MonacoEditor
+              content={content}
+              filePath={filePath}
+              readOnly={false}
+              onSave={handleSave}
+              onDirtyChange={handleDirtyChange}
+            />
+          );
+        }
+        return <JsonViewer content={content} onEdit={() => setEditing(true)} />;
       case 'pdf':
         return <Suspense fallback={<div className="p-4 text-xs text-muted-foreground">Loading PDF viewer...</div>}><PDFViewer filePath={filePath} rpc={rpc} /></Suspense>;
       case 'excel':

--- a/desktop/src/components/FileViewer.tsx
+++ b/desktop/src/components/FileViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
-import { MonacoEditor } from './viewers/MonacoEditor';
+import { MonacoEditor, type MonacoEditorHandle } from './viewers/MonacoEditor';
 import { MarkdownViewer } from './viewers/MarkdownViewer';
 import { HtmlViewer } from './viewers/HtmlViewer';
 import { JsonViewer } from './viewers/JsonViewer';
@@ -12,6 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { X, Pencil, Eye } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { FILE_PREVIEW_EVENT, supportsFilePreview } from '@/lib/file-preview';
+import { toast } from 'sonner';
 
 type Props = {
   filePath: string;
@@ -66,6 +67,8 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
   const [editing, setEditing] = useState(() => !['html', 'json'].includes(getFileType(filePath)));
   const [dirty, setDirty] = useState(false);
   const [version, setVersion] = useState(0); // bump to force reload
+  const editorRef = useRef<MonacoEditorHandle>(null);
+  const previewTransitionRef = useRef(false);
   const fileType = getFileType(filePath);
   const fileName = getFileName(filePath);
   const canEdit = fileType === 'code' || supportsFilePreview(fileType);
@@ -113,6 +116,25 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
     onDirtyChange?.(d);
   }, [onDirtyChange]);
 
+  const showPreview = useCallback(async () => {
+    if (!supportsFilePreview(fileType)) {
+      setEditing(false);
+      return;
+    }
+    if (previewTransitionRef.current) return;
+    previewTransitionRef.current = true;
+    try {
+      await editorRef.current?.flush();
+      setEditing(false);
+    } catch (err) {
+      toast.error('Could not save before opening preview', {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      previewTransitionRef.current = false;
+    }
+  }, [fileType]);
+
   // File watcher: reload content when file changes externally
   const dirtyRef = useRef(dirty);
   const editingRef = useRef(editing);
@@ -151,11 +173,11 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
       const detail = (event as CustomEvent<{ filePath?: string }>).detail;
       if (!detail?.filePath) return;
       if (detail.filePath !== filePath) return;
-      setEditing(false);
+      void showPreview();
     };
     window.addEventListener(FILE_PREVIEW_EVENT, onPreview as EventListener);
     return () => window.removeEventListener(FILE_PREVIEW_EVENT, onPreview as EventListener);
-  }, [filePath, fileType]);
+  }, [filePath, fileType, showPreview]);
 
   const renderViewer = () => {
     if (loading) {
@@ -177,6 +199,7 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
       case 'code':
         return (
           <MonacoEditor
+            ref={editorRef}
             content={content}
             filePath={filePath}
             readOnly={!editing}
@@ -188,6 +211,7 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
         if (editing) {
           return (
             <MonacoEditor
+              ref={editorRef}
               content={content}
               filePath={filePath}
               readOnly={false}
@@ -201,6 +225,7 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
         if (editing) {
           return (
             <MonacoEditor
+              ref={editorRef}
               content={content}
               filePath={filePath}
               readOnly={false}
@@ -214,6 +239,7 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
         if (editing) {
           return (
             <MonacoEditor
+              ref={editorRef}
               content={content}
               filePath={filePath}
               readOnly={false}
@@ -249,7 +275,7 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
                 'flex items-center gap-1 px-2 py-0.5 rounded text-[10px] transition-colors',
                 !editing ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/50'
               )}
-              onClick={() => setEditing(false)}
+              onClick={() => void showPreview()}
             >
               <Eye className="w-3 h-3" />
               View
@@ -290,7 +316,10 @@ export function FileViewer({ filePath, rpc, onClose, headerless, onDirtyChange, 
             variant="ghost"
             size="sm"
             className="h-6 px-2 text-[10px]"
-            onClick={() => setEditing(!editing)}
+            onClick={() => {
+              if (editing) void showPreview();
+              else setEditing(true);
+            }}
           >
             {editing ? <><Eye className="w-3 h-3 mr-1" />View</> : <><Pencil className="w-3 h-3 mr-1" />Edit</>}
           </Button>

--- a/desktop/src/components/ShortcutHelp.tsx
+++ b/desktop/src/components/ShortcutHelp.tsx
@@ -21,7 +21,7 @@ export const SHORTCUTS = [
   ]},
   { section: 'Editor', items: [
     { keys: '⌘S', desc: 'Save file' },
-    { keys: '⌘⇧V', desc: 'Toggle markdown preview' },
+    { keys: '⌘⇧V', desc: 'Show file preview' },
     { keys: '⌃`', desc: 'Open terminal' },
     { keys: 'Esc', desc: 'Stop agent' },
   ]},

--- a/desktop/src/components/viewers/HtmlViewer.tsx
+++ b/desktop/src/components/viewers/HtmlViewer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ShieldAlert, Globe } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  filePath: string;
+  // Test seam. Browsers refuse to frame file:// from an http page, so the
+  // harness swaps in an http URL for the same bytes. Production leaves it
+  // unset and renders straight off disk.
+  resolveSrc?: (path: string) => string;
+};
+
+type PreviewApi = {
+  htmlPreviewPartition?: string;
+  setHtmlPreviewAllowRemote?: (webContentsId: number, allow: boolean) => Promise<boolean>;
+  onHtmlPreviewBlocked?: (cb: (info: { url: string; webContentsId: number }) => void) => () => void;
+};
+
+type PreviewWebview = HTMLElement & {
+  getWebContentsId: () => number;
+  reload: () => void;
+};
+
+function fileUrl(path: string): string {
+  return 'file://' + path.split('/').map(encodeURIComponent).join('/');
+}
+
+// Rendered HTML, not source. Loaded from file:// rather than srcdoc so relative
+// stylesheets and images resolve the way they do on disk.
+//
+// Remote loads are blocked by default. HTML written by an agent is untrusted:
+// <img src="https://x/?d=..."> in a generated file turns a preview into an
+// exfiltration channel. Same posture an email client takes to remote images.
+export function HtmlViewer({ filePath, resolveSrc }: Props) {
+  const api = (window as unknown as { electronAPI?: PreviewApi }).electronAPI;
+  const partition = api?.htmlPreviewPartition;
+  const [blocked, setBlocked] = useState<string[]>([]);
+  const [allowRemote, setAllowRemote] = useState(false);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const webviewRef = useRef<PreviewWebview | null>(null);
+  const url = useMemo(() => (resolveSrc ? resolveSrc(filePath) : fileUrl(filePath)), [filePath, resolveSrc]);
+
+  useEffect(() => {
+    if (!api?.onHtmlPreviewBlocked) return;
+    return api.onHtmlPreviewBlocked(({ url: blockedUrl, webContentsId }) => {
+      if (webviewRef.current?.getWebContentsId() !== webContentsId) return;
+      setBlocked(prev => (prev.includes(blockedUrl) ? prev : [...prev, blockedUrl]));
+    });
+  }, [api]);
+
+  useEffect(() => {
+    setBlocked([]);
+    setAllowRemote(false);
+  }, [filePath]);
+
+  // <webview> is not a React element, and it has to carry the partition so the
+  // main process can scope request blocking to previews alone.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || !partition) return;
+    host.innerHTML = '';
+    const view = document.createElement('webview') as PreviewWebview;
+    webviewRef.current = view;
+    view.setAttribute('src', url);
+    view.setAttribute('partition', partition);
+    view.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes,javascript=no');
+    view.style.width = '100%';
+    view.style.height = '100%';
+    view.style.border = '0';
+    host.appendChild(view);
+    return () => {
+      const webContentsId = view.getWebContentsId();
+      if (webContentsId) void api?.setHtmlPreviewAllowRemote?.(webContentsId, false);
+      webviewRef.current = null;
+      host.innerHTML = '';
+    };
+  }, [api, url, partition]);
+
+  const toggleRemote = async () => {
+    const view = webviewRef.current;
+    if (!view) return;
+    const next = !allowRemote;
+    const applied = await api?.setHtmlPreviewAllowRemote?.(view.getWebContentsId(), next);
+    if (applied !== next) return;
+    setBlocked([]);
+    setAllowRemote(applied);
+    view.reload();
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 bg-white">
+      {(blocked.length > 0 || allowRemote) && (
+        <div className={cn(
+          'flex items-center gap-2 px-3 py-1.5 border-b shrink-0 text-[10px]',
+          allowRemote ? 'bg-warning/10 border-warning/40 text-warning' : 'bg-secondary border-border text-muted-foreground',
+        )}>
+          {allowRemote ? <Globe className="w-3 h-3 shrink-0" /> : <ShieldAlert className="w-3 h-3 shrink-0" />}
+          <span className="flex-1 truncate">
+            {allowRemote
+              ? 'Remote content allowed for this preview'
+              : `Blocked ${blocked.length} remote request${blocked.length === 1 ? '' : 's'}`}
+          </span>
+          <button
+            className="px-1.5 py-0.5 rounded hover:bg-background/60 transition-colors shrink-0"
+            onClick={toggleRemote}
+          >
+            {allowRemote ? 'Block again' : 'Allow'}
+          </button>
+        </div>
+      )}
+      {partition ? (
+        <div ref={hostRef} className="flex-1 min-h-0" />
+      ) : (
+        // Outside Electron (tests, harness) there is no session to scope
+        // blocking to, so fall back to a fully sandboxed iframe.
+        <iframe
+          title="preview"
+          src={url}
+          sandbox=""
+          className="flex-1 min-h-0 w-full border-0 bg-white"
+        />
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/viewers/JsonViewer.tsx
+++ b/desktop/src/components/viewers/JsonViewer.tsx
@@ -1,0 +1,425 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronsDown,
+  ChevronsUp,
+  Copy,
+  FileJson,
+  Pencil,
+  Search,
+} from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+import { getPalette } from '@/lib/palettes';
+import {
+  formatJsonPath,
+  jsonPathKey,
+  parseJson,
+  serializeJsonValue,
+  type JsonPathSegment,
+  type JsonValue,
+} from '@/lib/json-viewer';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  content: string;
+  onEdit: () => void;
+};
+
+type SearchResult = {
+  visible: Set<string>;
+  matched: Set<string>;
+  expanded: Set<string>;
+  count: number;
+  capped: boolean;
+};
+
+const PAGE_SIZE = 200;
+const SEARCH_LIMIT = 300;
+const SEARCH_SCAN_LIMIT = 50_000;
+
+function isContainer(value: JsonValue): value is JsonValue[] | { [key: string]: JsonValue } {
+  return value !== null && typeof value === 'object';
+}
+
+function entries(value: JsonValue): [JsonPathSegment, JsonValue][] {
+  if (Array.isArray(value)) return value.map((item, index) => [index, item]);
+  if (isContainer(value)) return Object.entries(value);
+  return [];
+}
+
+function primitiveText(value: JsonValue): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  return String(value);
+}
+
+function pathSegmentLabel(segment: JsonPathSegment): string {
+  if (typeof segment === 'number') return `[${segment}]`;
+  if (/^[A-Za-z_$][\w$]*$/.test(segment)) return `.${segment}`;
+  return `[${JSON.stringify(segment)}]`;
+}
+
+function collectExpanded(value: JsonValue, maxDepth: number): Set<string> {
+  const result = new Set<string>();
+
+  const visit = (current: JsonValue, path: JsonPathSegment[], depth: number) => {
+    if (!isContainer(current) || depth >= maxDepth) return;
+    result.add(jsonPathKey(path));
+    for (const [segment, child] of entries(current).slice(0, PAGE_SIZE)) {
+      visit(child, [...path, segment], depth + 1);
+    }
+  };
+
+  visit(value, [], 0);
+  return result;
+}
+
+function searchJson(value: JsonValue, rawQuery: string): SearchResult | null {
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) return null;
+
+  const visible = new Set<string>();
+  const matched = new Set<string>();
+  const expanded = new Set<string>();
+  let count = 0;
+  let capped = false;
+  let visited = 0;
+
+  const visit = (current: JsonValue, path: JsonPathSegment[], label?: JsonPathSegment): boolean => {
+    if (count >= SEARCH_LIMIT || visited >= SEARCH_SCAN_LIMIT) {
+      capped = true;
+      return false;
+    }
+    visited += 1;
+
+    const key = jsonPathKey(path);
+    const labelMatch = label !== undefined && String(label).toLowerCase().includes(query);
+    const valueMatch = !isContainer(current) && primitiveText(current).toLowerCase().includes(query);
+    const ownMatch = labelMatch || valueMatch;
+    if (ownMatch) {
+      matched.add(key);
+      count += 1;
+    }
+
+    let childMatch = false;
+    if (isContainer(current)) {
+      for (const [segment, child] of entries(current)) {
+        if (visit(child, [...path, segment], segment)) childMatch = true;
+        if (count >= SEARCH_LIMIT) {
+          capped = true;
+          break;
+        }
+      }
+    }
+
+    if (ownMatch || childMatch) visible.add(key);
+    if (childMatch) expanded.add(key);
+    return ownMatch || childMatch;
+  };
+
+  visit(value, []);
+  return { visible, matched, expanded, count, capped };
+}
+
+export function JsonViewer({ content, onEdit }: Props) {
+  const parsed = useMemo(() => parseJson(content), [content]);
+  const { palette } = useTheme();
+  const colors = getPalette(palette).terminal;
+  const [query, setQuery] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set([jsonPathKey([])]));
+  const [pageSizes, setPageSizes] = useState<Record<string, number>>({});
+  const [selectedPath, setSelectedPath] = useState<JsonPathSegment[]>([]);
+  const [copied, setCopied] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const rowRefs = useRef(new Map<string, HTMLDivElement>());
+
+  const searchResult = useMemo(
+    () => parsed.ok ? searchJson(parsed.value, query) : null,
+    [parsed, query],
+  );
+
+  useEffect(() => {
+    setQuery('');
+    setExpanded(new Set([jsonPathKey([])]));
+    setPageSizes({});
+    setSelectedPath([]);
+  }, [content]);
+
+  const copyText = useCallback(async (text: string, token: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(token);
+      window.setTimeout(() => setCopied(current => current === token ? null : current), 1200);
+    } catch {}
+  }, []);
+
+  const revealPath = useCallback((path: JsonPathSegment[]) => {
+    setExpanded(current => {
+      const next = new Set(current);
+      for (let i = 0; i < path.length; i += 1) next.add(jsonPathKey(path.slice(0, i)));
+      return next;
+    });
+    setSelectedPath(path);
+    requestAnimationFrame(() => rowRefs.current.get(jsonPathKey(path))?.scrollIntoView({ block: 'nearest' }));
+  }, []);
+
+  if (!parsed.ok) {
+    const location = parsed.line && parsed.column ? `Line ${parsed.line}, column ${parsed.column}` : null;
+    return (
+      <div className="h-full flex items-start justify-center p-8 bg-background">
+        <div className="w-full max-w-xl rounded-lg border border-destructive/25 bg-destructive/5 p-5">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-4 h-4 mt-0.5 text-destructive shrink-0" />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold">This JSON is not valid</div>
+              {location && <div className="mt-1 text-xs text-destructive">{location}</div>}
+              <div className="mt-2 font-mono text-[11px] leading-5 text-muted-foreground break-words">
+                {parsed.message}
+              </div>
+              <button
+                type="button"
+                onClick={onEdit}
+                className="mt-4 inline-flex h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-[11px] font-medium hover:bg-secondary"
+              >
+                <Pencil className="w-3 h-3" />
+                Edit JSON
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const rootValue = parsed.value;
+  const effectiveExpanded = new Set(expanded);
+  searchResult?.expanded.forEach(key => effectiveExpanded.add(key));
+  const selectedKey = jsonPathKey(selectedPath);
+
+  const toggleExpanded = (key: string) => {
+    setExpanded(current => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const valueColor = (value: JsonValue): string => {
+    if (value === null) return colors.brightBlack;
+    if (typeof value === 'string') return colors.green;
+    if (typeof value === 'number') return colors.yellow;
+    if (typeof value === 'boolean') return colors.magenta;
+    return colors.foreground;
+  };
+
+  const renderNode = (
+    value: JsonValue,
+    path: JsonPathSegment[],
+    label: JsonPathSegment | 'root',
+    depth: number,
+  ): React.ReactNode => {
+    const key = jsonPathKey(path);
+    if (searchResult && !searchResult.visible.has(key)) return null;
+
+    const container = isContainer(value);
+    const open = container && effectiveExpanded.has(key);
+    const childEntries = container ? entries(value) : [];
+    const visibleChildren = searchResult
+      ? childEntries.filter(([segment]) => searchResult.visible.has(jsonPathKey([...path, segment])))
+      : childEntries;
+    const limit = searchResult ? visibleChildren.length : (pageSizes[key] ?? PAGE_SIZE);
+    const shownChildren = visibleChildren.slice(0, limit);
+    const countLabel = Array.isArray(value)
+      ? `${childEntries.length} ${childEntries.length === 1 ? 'item' : 'items'}`
+      : container
+        ? `${childEntries.length} ${childEntries.length === 1 ? 'key' : 'keys'}`
+        : null;
+    const pathText = formatJsonPath(path);
+    const valueToken = `value:${key}`;
+    const pathToken = `path:${key}`;
+
+    return (
+      <div key={key}>
+        <div
+          ref={node => {
+            if (node) rowRefs.current.set(key, node);
+            else rowRefs.current.delete(key);
+          }}
+          role="treeitem"
+          aria-expanded={container ? open : undefined}
+          aria-selected={selectedKey === key}
+          tabIndex={selectedKey === key ? 0 : -1}
+          className={cn(
+            'group flex h-7 min-w-0 items-center border-l-2 border-transparent pr-2 font-mono text-[12px] outline-none transition-colors',
+            'hover:bg-secondary/50 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring',
+            selectedKey === key && 'border-l-primary bg-secondary/70',
+            searchResult?.matched.has(key) && 'bg-primary/10',
+          )}
+          style={{ paddingLeft: `${8 + depth * 16}px` }}
+          onClick={() => setSelectedPath(path)}
+          onDoubleClick={() => container && toggleExpanded(key)}
+          onKeyDown={event => {
+            if (!container) return;
+            if (event.key === 'ArrowRight' && !open) toggleExpanded(key);
+            if (event.key === 'ArrowLeft' && open) toggleExpanded(key);
+          }}
+        >
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label={open ? `Collapse ${pathText}` : `Expand ${pathText}`}
+            className={cn('mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded hover:bg-background/70', !container && 'invisible')}
+            onClick={event => {
+              event.stopPropagation();
+              toggleExpanded(key);
+            }}
+          >
+            {open ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+          </button>
+
+          <span className="shrink-0" style={{ color: label === 'root' ? colors.blue : colors.foreground }}>
+            {label === 'root' ? 'root' : typeof label === 'number' ? `[${label}]` : JSON.stringify(label)}
+          </span>
+          {label !== 'root' && <span className="mr-2 text-muted-foreground">:</span>}
+
+          {container ? (
+            <>
+              <span style={{ color: colors.cyan }}>{Array.isArray(value) ? '[ ]' : '{ }'}</span>
+              <span className="ml-2 text-[10px] text-muted-foreground">{countLabel}</span>
+            </>
+          ) : (
+            <span className="min-w-0 truncate" style={{ color: valueColor(value) }} title={primitiveText(value)}>
+              {primitiveText(value)}
+            </span>
+          )}
+
+          <span className="flex-1" />
+          <div className="ml-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+            <button
+              type="button"
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground"
+              title="Copy value"
+              aria-label={`Copy value at ${pathText}`}
+              onClick={event => {
+                event.stopPropagation();
+                void copyText(serializeJsonValue(value), valueToken);
+              }}
+            >
+              {copied === valueToken ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+            </button>
+            <button
+              type="button"
+              className="flex h-5 px-1.5 items-center justify-center rounded text-[9px] text-muted-foreground hover:bg-background hover:text-foreground"
+              title="Copy JSONPath"
+              aria-label={`Copy JSONPath ${pathText}`}
+              onClick={event => {
+                event.stopPropagation();
+                void copyText(pathText, pathToken);
+              }}
+            >
+              {copied === pathToken ? <Check className="w-3 h-3" /> : '$'}
+            </button>
+          </div>
+        </div>
+
+        {open && (
+          <div role="group">
+            {shownChildren.map(([segment, child]) => renderNode(child, [...path, segment], segment, depth + 1))}
+            {shownChildren.length < visibleChildren.length && (
+              <button
+                type="button"
+                className="h-7 text-[11px] text-primary hover:underline"
+                style={{ marginLeft: `${32 + depth * 16}px` }}
+                onClick={() => setPageSizes(current => ({ ...current, [key]: limit + PAGE_SIZE }))}
+              >
+                Show {Math.min(PAGE_SIZE, visibleChildren.length - shownChildren.length)} more
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background text-foreground"
+      onKeyDownCapture={event => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
+          event.preventDefault();
+          searchInputRef.current?.focus();
+        }
+      }}
+    >
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/70 px-2">
+        <div className="relative min-w-[160px] max-w-md flex-1">
+          <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            ref={searchInputRef}
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            placeholder="Search keys and values"
+            aria-label="Search JSON"
+            className="h-7 w-full rounded-md border border-border bg-transparent pl-7 pr-2 text-[11px] outline-none placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring/40"
+          />
+        </div>
+        {searchResult && (
+          <span className="text-[10px] tabular-nums text-muted-foreground">
+            {searchResult.count} {searchResult.count === 1 ? 'match' : 'matches'}{searchResult.capped ? ' · partial' : ''}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setExpanded(new Set())}
+          className="inline-flex h-7 items-center gap-1 rounded px-2 text-[10px] text-muted-foreground hover:bg-secondary hover:text-foreground"
+          title="Collapse all"
+        >
+          <ChevronsUp className="w-3.5 h-3.5" />
+          Collapse
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded(collectExpanded(rootValue, 2))}
+          className="inline-flex h-7 items-center gap-1 rounded px-2 text-[10px] text-muted-foreground hover:bg-secondary hover:text-foreground"
+          title="Expand two levels"
+        >
+          <ChevronsDown className="w-3.5 h-3.5" />
+          Expand 2
+        </button>
+      </div>
+
+      <div className="flex h-8 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border/60 bg-muted/20 px-2 font-mono text-[10px]">
+        <FileJson className="mr-1 h-3.5 w-3.5 shrink-0" style={{ color: colors.cyan }} />
+        <button type="button" onClick={() => revealPath([])} className="rounded px-1 py-0.5 hover:bg-secondary">$</button>
+        {selectedPath.map((segment, index) => (
+          <button
+            type="button"
+            key={`${index}:${String(segment)}`}
+            onClick={() => revealPath(selectedPath.slice(0, index + 1))}
+            className="whitespace-nowrap rounded px-0.5 py-0.5 text-muted-foreground hover:bg-secondary hover:text-foreground"
+          >
+            {pathSegmentLabel(segment)}
+          </button>
+        ))}
+        <span className="flex-1" />
+        <button
+          type="button"
+          className="ml-2 flex h-5 shrink-0 items-center gap-1 rounded px-1.5 text-muted-foreground hover:bg-secondary hover:text-foreground"
+          onClick={() => void copyText(formatJsonPath(selectedPath), `selected:${selectedKey}`)}
+        >
+          {copied === `selected:${selectedKey}` ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+          JSONPath
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto py-1" role="tree" aria-label="JSON document">
+        {searchResult && searchResult.count === 0
+          ? <div className="px-4 py-10 text-center text-xs text-muted-foreground">No matching keys or values</div>
+          : renderNode(rootValue, [], 'root', 0)}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/viewers/MonacoEditor.tsx
+++ b/desktop/src/components/viewers/MonacoEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
+import { forwardRef, useRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import Editor, { loader, type OnMount } from '@monaco-editor/react';
 import type { editor as monacoEditor } from 'monaco-editor';
 import { useTheme } from '../../hooks/useTheme';
@@ -50,7 +50,14 @@ type Props = {
   onDirtyChange?: (dirty: boolean) => void;
 };
 
-export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDirtyChange }: Props) {
+export type MonacoEditorHandle = {
+  flush: () => Promise<void>;
+};
+
+export const MonacoEditor = forwardRef<MonacoEditorHandle, Props>(function MonacoEditor(
+  { content, filePath, readOnly = false, onSave, onDirtyChange },
+  ref,
+) {
   const { theme, palette } = useTheme();
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
   const [monacoTheme, setMonacoTheme] = useState(theme === 'dark' ? 'vs-dark' : 'vs');
@@ -63,6 +70,35 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
 
   // Track whether user has made edits (vs content prop changing)
   const userDirtyRef = useRef(false);
+
+  const saveCurrent = useCallback(async () => {
+    const editor = editorRef.current;
+    const save = onSaveRef.current;
+    if (!editor || !save || !userDirtyRef.current) return;
+
+    const value = editor.getValue();
+    await save(value);
+
+    const latestValue = editorRef.current?.getValue();
+    const stillDirty = latestValue != null && latestValue !== value;
+    originalContentRef.current = value;
+    userDirtyRef.current = stillDirty;
+    onDirtyChangeRef.current?.(stillDirty);
+  }, []);
+
+  const flush = useCallback(async () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.updateOptions({ readOnly: true });
+    try {
+      await saveCurrent();
+    } catch (err) {
+      editor.updateOptions({ readOnly });
+      throw err;
+    }
+  }, [readOnly, saveCurrent]);
+
+  useImperativeHandle(ref, () => ({ flush }), [flush]);
 
   // Build a Monaco theme from active CSS palette tokens so editor tracks palette changes.
   useEffect(() => {
@@ -187,8 +223,7 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
       // KeyMod.CtrlCmd | KeyCode.KeyS
       2048 | 49,
       () => {
-        const value = editor.getValue();
-        onSaveRef.current?.(value);
+        void saveCurrent().catch(() => {});
       }
     );
 
@@ -203,13 +238,7 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
       if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
       if (isDirty) {
         autosaveTimerRef.current = setTimeout(() => {
-          const currentValue = editorRef.current?.getValue();
-          if (currentValue != null && currentValue !== originalContentRef.current) {
-            onSaveRef.current?.(currentValue);
-            originalContentRef.current = currentValue;
-            userDirtyRef.current = false;
-            onDirtyChangeRef.current?.(false);
-          }
+          void saveCurrent().catch(() => {});
         }, 1000);
       }
     });
@@ -220,7 +249,7 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
     // Opening from anywhere else (cmd+P, tab click) still focuses normally.
     const treeHasFocus = !!document.activeElement?.closest?.('[data-file-tree]');
     if (!treeHasFocus) editor.focus();
-  }, []);
+  }, [saveCurrent]);
 
   const language = getMonacoLanguage(filePath);
 
@@ -271,4 +300,4 @@ export function MonacoEditor({ content, filePath, readOnly = false, onSave, onDi
       }
     />
   );
-}
+});

--- a/desktop/src/hooks/pane-roles.sim.test.tsx
+++ b/desktop/src/hooks/pane-roles.sim.test.tsx
@@ -205,4 +205,17 @@ describe('pane role targeting', () => {
     act(() => { r.result.current.tabs.openFileTab('/a/two.ts'); });
     console.log('  file again     :', snapshot(r), `(panes=${paneCount(r)})`);
   });
+
+  it('12. closing a chat prunes its in-memory draft', () => {
+    const r = setup();
+    const chat = r.result.current.tabs.tabs.find(isChatTab)!;
+    act(() => {
+      r.result.current.tabs.chatDrafts.set(chat.sessionKey, {
+        text: 'discard me',
+        images: [],
+      });
+      r.result.current.tabs.closeTab(chat.id);
+    });
+    expect(r.result.current.tabs.chatDrafts.has(chat.sessionKey)).toBe(false);
+  });
 });

--- a/desktop/src/hooks/useGateway.ts
+++ b/desktop/src/hooks/useGateway.ts
@@ -1697,7 +1697,14 @@ export function useGateway() {
 
       case 'fs.change': {
         const d = data as { path: string; eventType: string; filename: string | null };
-        fsChangeListenersRef.current.forEach(listener => listener(d.path));
+        // The watch is recursive, so filename is a path relative to the watch
+        // root and may sit several levels down. Report the directory that
+        // actually changed rather than always the root, so a listener can
+        // refresh the level the user is looking at instead of only the top.
+        const rel = d.filename ? d.filename.replace(/\\/g, '/') : '';
+        const lastSlash = rel.lastIndexOf('/');
+        const changedDir = lastSlash > 0 ? `${d.path}/${rel.slice(0, lastSlash)}` : d.path;
+        fsChangeListenersRef.current.forEach(listener => listener(changedDir));
         break;
       }
 

--- a/desktop/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/desktop/src/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+function ShortcutHarness({ actions }: { actions: Parameters<typeof useKeyboardShortcuts>[0] }) {
+  useKeyboardShortcuts(actions);
+  return null;
+}
+
+function makeActions(): Parameters<typeof useKeyboardShortcuts>[0] {
+  return {
+    newTab: vi.fn(),
+    closeTab: vi.fn(),
+    nextTab: vi.fn(),
+    prevTab: vi.fn(),
+    focusTabByIndex: vi.fn(),
+    openQuickOpen: vi.fn(),
+    previewFile: vi.fn(),
+    toggleFiles: vi.fn(),
+    openSettings: vi.fn(),
+    focusInput: vi.fn(),
+    abortAgent: vi.fn(),
+    splitHorizontal: vi.fn(),
+    splitVertical: vi.fn(),
+    splitGrid: vi.fn(),
+    resetLayout: vi.fn(),
+    focusGroupLeft: vi.fn(),
+    focusGroupRight: vi.fn(),
+    focusGroupUp: vi.fn(),
+    focusGroupDown: vi.fn(),
+    openTerminal: vi.fn(),
+    openGlobalSearch: vi.fn(),
+    openShortcutHelp: vi.fn(),
+  };
+}
+
+afterEach(cleanup);
+
+describe('file preview shortcut', () => {
+  it('routes cmd+shift+v through the universal preview action', () => {
+    const actions = makeActions();
+    render(<ShortcutHarness actions={actions} />);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'v',
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+    }));
+
+    expect(actions.previewFile).toHaveBeenCalledOnce();
+  });
+});

--- a/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -7,7 +7,7 @@ type ShortcutActions = {
   prevTab: () => void;
   focusTabByIndex: (index: number) => void;
   openQuickOpen: () => void;
-  previewMarkdown: () => void;
+  previewFile: () => void;
   toggleFiles: () => void;
   openSettings: () => void;
   focusInput: () => void;
@@ -105,10 +105,10 @@ export function useKeyboardShortcuts(actions: ShortcutActions, options: Shortcut
         return;
       }
 
-      // Cmd+Shift+V — render markdown preview in active markdown tab
+      // Cmd+Shift+V — show the active file's preview mode
       if (e.key.toLowerCase() === 'v' && e.shiftKey && !e.altKey) {
         e.preventDefault();
-        actions.previewMarkdown();
+        actions.previewFile();
         return;
       }
 

--- a/desktop/src/hooks/useTabs.ts
+++ b/desktop/src/hooks/useTabs.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import type { useGateway } from './useGateway';
+import type { useGateway, ImageAttachment } from './useGateway';
 import type { useLayout, GroupId, PaneRole } from './useLayout';
 
 export type TabType = 'chat' | 'channels' | 'goals' | 'automation' | 'extensions' | 'agents' | 'memory' | 'research' | 'settings' | 'file' | 'diff' | 'terminal' | 'task' | 'pr';
@@ -68,6 +68,13 @@ export type ViewTab = {
 };
 
 export type Tab = ChatTab | ViewTab | FileTab | DiffTab | TerminalTab | TaskTab | PrTab;
+
+export type ChatDraft = {
+  text: string;
+  images: ImageAttachment[];
+};
+
+export type ChatDraftStore = Map<string, ChatDraft>;
 
 export function isChatTab(tab: Tab): tab is ChatTab {
   return tab.type === 'chat';
@@ -160,6 +167,7 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
   const closingRef = useRef(0);
   const subscribedSessionKeysRef = useRef<Set<string>>(new Set());
   const streamCountRef = useRef<Record<string, number>>({});
+  const chatDraftsRef = useRef<ChatDraftStore>(new Map());
   const [unreadBySession, setUnreadBySession] = useState<Record<string, number>>({});
   const [dirtyTabs, setDirtyTabs] = useState<Set<string>>(new Set());
 
@@ -925,6 +933,15 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     });
   }, [gw.sessionStates, tabs, layout.visibleGroups]);
 
+  // chat views remount when the pane layout changes. keep drafts at the tab
+  // lifetime, then prune them after a chat tab is actually closed.
+  useEffect(() => {
+    const liveSessionKeys = new Set(tabs.filter(isChatTab).map(tab => tab.sessionKey));
+    for (const sessionKey of chatDraftsRef.current.keys()) {
+      if (!liveSessionKeys.has(sessionKey)) chatDraftsRef.current.delete(sessionKey);
+    }
+  }, [tabs]);
+
   return {
     tabs,
     activeTabId,
@@ -945,6 +962,7 @@ export function useTabs(gw: ReturnType<typeof useGateway>, layout: ReturnType<ty
     openPrTab,
     newChatTab,
     unreadBySession,
+    chatDrafts: chatDraftsRef.current,
     dirtyTabs,
     setTabDirty,
     updateTabLabel,

--- a/desktop/src/lib/file-preview.test.ts
+++ b/desktop/src/lib/file-preview.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { supportsFilePreview } from './file-preview';
+
+describe('file preview capability', () => {
+  it('covers every current source-to-preview viewer', () => {
+    expect(supportsFilePreview('markdown')).toBe(true);
+    expect(supportsFilePreview('html')).toBe(true);
+    expect(supportsFilePreview('json')).toBe(true);
+  });
+
+  it('does not turn read-only source into a preview mode', () => {
+    expect(supportsFilePreview('code')).toBe(false);
+    expect(supportsFilePreview('binary')).toBe(false);
+  });
+});

--- a/desktop/src/lib/file-preview.ts
+++ b/desktop/src/lib/file-preview.ts
@@ -1,0 +1,7 @@
+export const FILE_PREVIEW_EVENT = 'dorabot:file-preview';
+
+export type PreviewFileType = 'markdown' | 'html' | 'json';
+
+export function supportsFilePreview(fileType: string): fileType is PreviewFileType {
+  return fileType === 'markdown' || fileType === 'html' || fileType === 'json';
+}

--- a/desktop/src/lib/json-viewer.test.ts
+++ b/desktop/src/lib/json-viewer.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { formatJsonPath, parseJson, serializeJsonValue } from './json-viewer';
+
+describe('json viewer helpers', () => {
+  it('formats identifiers, array indexes, and escaped keys as JSONPath', () => {
+    expect(formatJsonPath(['users', 2, 'display name'])).toBe('$.users[2]["display name"]');
+    expect(formatJsonPath(['quote"key'])).toBe('$["quote\\"key"]');
+  });
+
+  it('accepts every valid JSON root type without rewriting it', () => {
+    expect(parseJson('null')).toEqual({ ok: true, value: null });
+    expect(parseJson('[true, 3, "x"]')).toEqual({ ok: true, value: [true, 3, 'x'] });
+  });
+
+  it('reports an invalid document with a source location when available', () => {
+    const result = parseJson('{\n  "ok": true,\n  nope\n}');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message.length).toBeGreaterThan(0);
+    expect(result.line).toBe(3);
+    expect(result.column).toBeGreaterThan(0);
+  });
+
+  it('copies strings as text and containers as formatted JSON', () => {
+    expect(serializeJsonValue('hello')).toBe('hello');
+    expect(serializeJsonValue({ ok: true })).toBe('{\n  "ok": true\n}');
+  });
+});

--- a/desktop/src/lib/json-viewer.ts
+++ b/desktop/src/lib/json-viewer.ts
@@ -1,0 +1,55 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonPathSegment = string | number;
+
+export type JsonParseResult =
+  | { ok: true; value: JsonValue }
+  | { ok: false; message: string; line?: number; column?: number };
+
+export function formatJsonPath(path: JsonPathSegment[]): string {
+  return path.reduce<string>((result, segment) => {
+    if (typeof segment === 'number') return `${result}[${segment}]`;
+    if (/^[A-Za-z_$][\w$]*$/.test(segment)) return `${result}.${segment}`;
+    return `${result}[${JSON.stringify(segment)}]`;
+  }, '$');
+}
+
+export function jsonPathKey(path: JsonPathSegment[]): string {
+  return JSON.stringify(path);
+}
+
+export function parseJson(content: string): JsonParseResult {
+  try {
+    return { ok: true, value: JSON.parse(content) as JsonValue };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const lineColumn = message.match(/line\s+(\d+)\s+column\s+(\d+)/i);
+    if (lineColumn) {
+      return {
+        ok: false,
+        message,
+        line: Number(lineColumn[1]),
+        column: Number(lineColumn[2]),
+      };
+    }
+
+    const position = message.match(/position\s+(\d+)/i);
+    if (!position) return { ok: false, message };
+
+    const offset = Math.min(Number(position[1]), content.length);
+    const before = content.slice(0, offset);
+    const lines = before.split('\n');
+    return {
+      ok: false,
+      message,
+      line: lines.length,
+      column: (lines.at(-1)?.length ?? 0) + 1,
+    };
+  }
+}
+
+export function serializeJsonValue(value: JsonValue): string {
+  if (typeof value === 'string') return value;
+  if (value === null || typeof value !== 'object') return String(value);
+  return JSON.stringify(value, null, 2);
+}

--- a/desktop/src/views/Chat.tsx
+++ b/desktop/src/views/Chat.tsx
@@ -4,6 +4,7 @@ import { DorabotSprite } from '../components/DorabotSprite';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { useGateway, ChatItem, AskUserQuestion, ImageAttachment, PendingElicitation, CodexModelCatalog, ProviderInputItem } from '../hooks/useGateway';
+import type { ChatDraftStore } from '../hooks/useTabs';
 import { ElicitationForm } from '../components/ElicitationForm';
 import { ApprovalList } from '@/components/approval-ui';
 import { ToolUI } from '@/components/tool-ui';
@@ -63,6 +64,7 @@ type Props = {
   agentStatus: string;
   pendingQuestion: AskUserQuestion | null;
   sessionKey?: string;
+  drafts: ChatDraftStore;
   onNavigateSettings?: () => void;
   onOpenFile?: (filePath: string) => void;
   onOpenDiff?: (opts: { filePath: string; oldContent: string; newContent: string; label?: string }) => void;
@@ -1210,7 +1212,7 @@ function AssistantTextWithReply({
   );
 }
 
-export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, sessionKey, onNavigateSettings, onOpenFile, onOpenDiff, onClearChat, onNewTab }: Props) {
+export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, sessionKey, drafts, onNavigateSettings, onOpenFile, onOpenDiff, onClearChat, onNewTab }: Props) {
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [attachedImages, setAttachedImages] = useState<ImageAttachment[]>([]);
@@ -1239,7 +1241,6 @@ export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, ses
   const slashListRef = useRef<HTMLDivElement>(null);
   const atListRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef<{ y: number; height: number } | null>(null);
-  const draftsRef = useRef<Record<string, { text: string; images: ImageAttachment[] }>>({});
   const liveInputRef = useRef(input);
   liveInputRef.current = input;
   const liveImagesRef = useRef(attachedImages);
@@ -1251,12 +1252,17 @@ export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, ses
   const activeState = sessionKey ? gateway.sessionStates[sessionKey] : undefined;
   const pendingElicitation = activeState?.pendingElicitation ?? null;
 
-  // Save/restore input draft and images per session when switching tabs
+  // save/restore input draft and images per session when switching tabs or panes
   useEffect(() => {
     if (!sessionKey) return;
     const sk = sessionKey;
-    setInput(draftsRef.current[sk]?.text || '');
-    setAttachedImages(draftsRef.current[sk]?.images || []);
+    const draft = drafts.get(sk);
+    const text = draft?.text || '';
+    const images = draft ? [...draft.images] : [];
+    liveInputRef.current = text;
+    liveImagesRef.current = images;
+    setInput(text);
+    setAttachedImages(images);
     // Reset ephemeral picker state
     setSlashOpen(false);
     setSlashFilter('');
@@ -1265,12 +1271,15 @@ export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, ses
     setAtStartPos(-1);
     setActiveSkill(null);
     return () => {
-      draftsRef.current[sk] = {
-        text: liveInputRef.current,
-        images: liveImagesRef.current,
-      };
+      const text = liveInputRef.current;
+      const images = liveImagesRef.current;
+      if (text || images.length > 0) {
+        drafts.set(sk, { text, images: [...images] });
+      } else {
+        drafts.delete(sk);
+      }
     };
-  }, [sessionKey]);
+  }, [drafts, sessionKey]);
 
   // Seed message history from existing chat items so ArrowUp works after reload
   useEffect(() => {
@@ -1506,8 +1515,15 @@ export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, ses
 
     const images = attachedImages.length > 0 ? [...attachedImages] : undefined;
     nextAutoScrollBehaviorRef.current = 'smooth';
+    const remainingText = overridePrompt ? input : '';
     if (!overridePrompt) setInput('');
     setAttachedImages([]);
+    liveInputRef.current = remainingText;
+    liveImagesRef.current = [];
+    if (sessionKey) {
+      if (remainingText) drafts.set(sessionKey, { text: remainingText, images: [] });
+      else drafts.delete(sessionKey);
+    }
     setInputHeight(null);
     setSlashOpen(false);
     setSlashFilter('');
@@ -1527,6 +1543,12 @@ export function ChatView({ gateway, chatItems, agentStatus, pendingQuestion, ses
     setSlashOpen(false);
     setSlashFilter('');
     setInput('');
+    liveInputRef.current = '';
+    if (sessionKey) {
+      const images = liveImagesRef.current;
+      if (images.length > 0) drafts.set(sessionKey, { text: '', images: [...images] });
+      else drafts.delete(sessionKey);
+    }
 
     if (item.type === 'command') {
       switch (item.command) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:codex-provider": "node scripts/smoke-codex-145.mjs",
     "test:claude-provider": "node scripts/smoke-claude-sdk.mjs",
     "test:model-catalog": "node scripts/test-model-catalog.mjs",
+    "test:oauth-refresh": "tsx scripts/test-oauth-refresh.ts",
     "test:fs-ops": "tsx scripts/test-fs-ops.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:claude-provider": "node scripts/smoke-claude-sdk.mjs",
     "test:model-catalog": "node scripts/test-model-catalog.mjs",
     "test:oauth-refresh": "tsx scripts/test-oauth-refresh.ts",
+    "test:fs-watch-events": "tsx scripts/test-fs-watch-events.ts",
     "test:fs-ops": "tsx scripts/test-fs-ops.ts"
   },
   "dependencies": {

--- a/scripts/test-fs-watch-events.ts
+++ b/scripts/test-fs-watch-events.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { fsWatchDirectory, rememberFsWatchEvent, type FsWatchEvent } from '../src/gateway/fs-watch-events.js';
+
+assert.equal(fsWatchDirectory(null), '');
+assert.equal(fsWatchDirectory('root.txt'), '');
+assert.equal(fsWatchDirectory('src/one.ts'), 'src');
+assert.equal(fsWatchDirectory('src\\nested\\two.ts'), 'src/nested');
+
+const pending = new Map<string, FsWatchEvent>();
+rememberFsWatchEvent(pending, { eventType: 'change', filename: 'src/one.ts' });
+rememberFsWatchEvent(pending, { eventType: 'rename', filename: 'test/two.ts' });
+rememberFsWatchEvent(pending, { eventType: 'change', filename: 'src/three.ts' });
+
+assert.equal(pending.size, 2);
+assert.equal(pending.get('src')?.filename, 'src/three.ts');
+assert.equal(pending.get('test')?.filename, 'test/two.ts');
+
+console.log('fs watch event batching: passed');

--- a/scripts/test-oauth-refresh.ts
+++ b/scripts/test-oauth-refresh.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { canReuseAccessTokenAfterRefreshFailure } from '../src/providers/oauth-refresh.js';
+
+const now = 1_000_000;
+
+assert.equal(canReuseAccessTokenAfterRefreshFailure(now + 1, false, false, now), true);
+assert.equal(canReuseAccessTokenAfterRefreshFailure(now, false, false, now), false);
+assert.equal(canReuseAccessTokenAfterRefreshFailure(now + 1, true, false, now), false);
+assert.equal(canReuseAccessTokenAfterRefreshFailure(now + 1, false, true, now), false);
+
+const testHome = join(tmpdir(), `dorabot-oauth-refresh-${process.pid}`);
+const fakeBin = join(testHome, 'bin');
+const dorabotDir = join(testHome, '.dorabot');
+mkdirSync(fakeBin, { recursive: true });
+mkdirSync(dorabotDir, { recursive: true });
+
+for (const command of ['which', 'claude']) {
+  const path = join(fakeBin, command);
+  writeFileSync(path, '#!/bin/sh\nexit 1\n');
+  chmodSync(path, 0o755);
+}
+
+process.env.HOME = testHome;
+process.env.CODEX_HOME = join(testHome, '.codex');
+process.env.PATH = `${fakeBin}:${process.env.PATH || ''}`;
+delete process.env.ANTHROPIC_API_KEY;
+delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+delete process.env.OPENAI_API_KEY;
+
+const expiresAt = Date.now() + 240_000;
+writeFileSync(join(dorabotDir, '.claude-oauth.json'), JSON.stringify({
+  access_token: 'claude-access',
+  refresh_token: 'claude-refresh',
+  expires_at: expiresAt,
+}));
+writeFileSync(join(dorabotDir, '.codex-oauth.json'), JSON.stringify({
+  access_token: 'codex-access',
+  refresh_token: 'codex-refresh',
+  expires_at: expiresAt,
+  account_id: 'account-1',
+}));
+
+let refreshRequests = 0;
+let refreshStatus = 503;
+globalThis.fetch = async () => {
+  refreshRequests++;
+  return new Response('', { status: refreshStatus });
+};
+
+try {
+  const [{ ClaudeProvider }, { CodexProvider }] = await Promise.all([
+    import('../src/providers/claude.js'),
+    import('../src/providers/codex.js'),
+  ]);
+
+  const claudeStatus = await new ClaudeProvider().getAuthStatus();
+  assert.equal(claudeStatus.authenticated, true);
+  assert.equal(claudeStatus.reconnectRequired, false);
+  assert.equal(claudeStatus.tokenHealth, 'expiring');
+
+  const codexStatus = await new CodexProvider().getAuthStatus();
+  assert.equal(codexStatus.authenticated, true);
+  assert.equal(codexStatus.reconnectRequired, false);
+  assert.equal(codexStatus.tokenHealth, 'expiring');
+  assert.equal(refreshRequests, 2);
+
+  const expiredAt = Date.now() - 1;
+  writeFileSync(join(dorabotDir, '.claude-oauth.json'), JSON.stringify({
+    access_token: 'claude-access',
+    refresh_token: 'claude-refresh',
+    expires_at: expiredAt,
+  }));
+  writeFileSync(join(dorabotDir, '.codex-oauth.json'), JSON.stringify({
+    access_token: 'codex-access',
+    refresh_token: 'codex-refresh',
+    expires_at: expiredAt,
+    account_id: 'account-1',
+  }));
+
+  const expiredClaudeStatus = await new ClaudeProvider().getAuthStatus();
+  assert.equal(expiredClaudeStatus.authenticated, false);
+  assert.equal(expiredClaudeStatus.reconnectRequired, false);
+
+  const expiredCodexStatus = await new CodexProvider().getAuthStatus();
+  assert.equal(expiredCodexStatus.authenticated, false);
+  assert.equal(expiredCodexStatus.reconnectRequired, false);
+
+  refreshStatus = 400;
+  writeFileSync(join(dorabotDir, '.claude-oauth.json'), JSON.stringify({
+    access_token: 'claude-access',
+    refresh_token: 'claude-refresh',
+    expires_at: Date.now() + 240_000,
+  }));
+  writeFileSync(join(dorabotDir, '.codex-oauth.json'), JSON.stringify({
+    access_token: 'codex-access',
+    refresh_token: 'codex-refresh',
+    expires_at: Date.now() + 240_000,
+    account_id: 'account-1',
+  }));
+
+  const rejectedClaudeStatus = await new ClaudeProvider().getAuthStatus();
+  assert.equal(rejectedClaudeStatus.authenticated, false);
+  assert.equal(rejectedClaudeStatus.reconnectRequired, true);
+
+  const rejectedCodexStatus = await new CodexProvider().getAuthStatus();
+  assert.equal(rejectedCodexStatus.authenticated, false);
+  assert.equal(rejectedCodexStatus.reconnectRequired, true);
+  assert.equal(refreshRequests, 6);
+} finally {
+  rmSync(testHome, { recursive: true, force: true });
+}
+
+console.log('oauth refresh fallback: passed');

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,3 @@
-import { mkdirSync } from 'node:fs';
-import { execSync } from 'node:child_process';
 import type { Config, SandboxSettings } from './config.js';
 import type { RunHandle } from './providers/types.js';
 import { getProvider } from './providers/index.js';
@@ -21,114 +19,12 @@ function resolveSandbox(sandbox: SandboxSettings, channel?: string): SandboxSett
 import { buildSystemPrompt } from './system-prompt.js';
 import { createAgentMcpServer } from './tools/index.js';
 import { getEligibleSkills, matchSkillToPrompt, type Skill } from './skills/loader.js';
-import { applyPersistedSkillEnv, mergeSkillEnv } from './skills/env.js';
+import { applyPersistedSkillEnv } from './skills/env.js';
 import { createDefaultHooks, mergeHooks, type HookEvent, type HookCallbackMatcher } from './hooks/index.js';
 import { getAllAgents } from './agents/definitions.js';
 import { SessionManager, sdkMessageToSession, type SessionMessage, type MessageMetadata } from './session/manager.js';
-import { loadWorkspaceFiles, ensureWorkspace, TMP_DIR } from './workspace.js';
-
-// Resolve shell PATH once at startup (Electron apps get minimal /usr/bin:/bin:/usr/sbin:/sbin)
-let _resolvedShellPath: string | null = null;
-function getShellPath(): string {
-  if (_resolvedShellPath !== null) return _resolvedShellPath;
-  const currentPath = process.env.PATH || '';
-
-  // If PATH already has common node locations, skip shell resolution
-  if (currentPath.includes('nvm') || currentPath.includes('homebrew') || currentPath.includes('fnm') || currentPath.includes('/usr/local/bin')) {
-    _resolvedShellPath = currentPath;
-    return _resolvedShellPath;
-  }
-
-  // Resolve from login shell
-  try {
-    const shell = process.env.SHELL || '/bin/zsh';
-    _resolvedShellPath = execSync(`${shell} -lc 'echo -n $PATH'`, {
-      timeout: 5000,
-      encoding: 'utf-8',
-    }).trim();
-  } catch {
-    _resolvedShellPath = currentPath;
-  }
-
-  // Append common node binary locations as fallback
-  const fallbackPaths = [
-    '/usr/local/bin',
-    '/opt/homebrew/bin',
-    `${process.env.HOME}/.nvm/current/bin`,
-    `${process.env.HOME}/.fnm/current/bin`,
-    `${process.env.HOME}/.volta/bin`,
-    `${process.env.HOME}/.local/bin`,
-  ];
-  for (const p of fallbackPaths) {
-    if (!_resolvedShellPath.includes(p)) {
-      _resolvedShellPath += `:${p}`;
-    }
-  }
-
-  return _resolvedShellPath;
-}
-
-// Resolve full environment from user's login shell once at startup.
-// macOS GUI apps (Electron) inherit a minimal launchd env that's missing
-// everything the user sets in .zshrc / .bash_profile (NVM, GOPATH, etc.).
-let _resolvedShellEnv: Record<string, string> | null = null;
-function getShellEnv(): Record<string, string> {
-  if (_resolvedShellEnv) return { ..._resolvedShellEnv };
-  try {
-    const shell = process.env.SHELL || '/bin/zsh';
-    // Use a unique marker so we ignore any stdout noise from .zshrc/.bashrc
-    // (welcome messages, neofetch, fortune, etc.)
-    const marker = '__DORABOT_ENV_START_8f3a__';
-    const raw = execSync(
-      `${shell} -lc 'echo ${marker} && env'`,
-      { timeout: 5000, encoding: 'utf-8' },
-    );
-    // Only parse lines after the marker
-    const markerIdx = raw.indexOf(marker);
-    const envSection = markerIdx >= 0 ? raw.slice(markerIdx + marker.length + 1) : raw;
-    const env: Record<string, string> = {};
-    // Parse KEY=VALUE lines. Env var names match [A-Za-z_][A-Za-z_0-9]*.
-    // Multiline values are rare; accumulate into the last key when a line
-    // doesn't look like a new variable assignment.
-    let lastKey = '';
-    for (const line of envSection.split('\n')) {
-      const m = line.match(/^([A-Za-z_][A-Za-z_0-9]*)=(.*)/);
-      if (m) {
-        lastKey = m[1];
-        env[lastKey] = m[2];
-      } else if (lastKey && line) {
-        env[lastKey] += '\n' + line;
-      }
-    }
-    _resolvedShellEnv = env;
-  } catch {
-    // Fallback: use process.env as-is
-    _resolvedShellEnv = {};
-    for (const [key, val] of Object.entries(process.env)) {
-      if (val !== undefined) _resolvedShellEnv[key] = val;
-    }
-  }
-  return { ..._resolvedShellEnv };
-}
-
-// clean env for SDK subprocess - strip vscode vars that cause file watcher crashes
-function cleanEnvForSdk(): Record<string, string> {
-  const env = mergeSkillEnv(getShellEnv());
-  // Strip vars that cause issues in the SDK subprocess
-  for (const key of Object.keys(env)) {
-    if (key.startsWith('VSCODE_')) delete env[key];
-  }
-  delete env.GIT_ASKPASS;
-  delete env.ELECTRON_RUN_AS_NODE;
-  delete env.CLAUDECODE;
-  // Ensure PATH includes node binary locations (critical for Electron)
-  env.PATH = getShellPath();
-  // use a clean tmpdir so SDK file watcher doesn't hit socket files
-  const sdkTmp = TMP_DIR;
-  mkdirSync(sdkTmp, { recursive: true });
-  env.TMPDIR = sdkTmp;
-  return env;
-}
+import { loadWorkspaceFiles, ensureWorkspace } from './workspace.js';
+import { getShellPath, cleanEnvForSdk } from './sdk-env.js';
 
 export type AgentOptions = {
   prompt: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,7 +128,12 @@ export type SecurityConfig = {
   autoApprove?: string[];
 };
 
-export type ProviderName = 'claude' | 'codex' | 'minimax' | 'openrouter';
+// Single source of truth. The type, the config setter's validation and the
+// provider factory all derive from this, so they cannot drift apart: the list
+// previously named four providers, the setter accepted three and the factory
+// implemented two, and picking one of the differences bricked every run.
+export const PROVIDER_NAMES = ['claude', 'codex'] as const;
+export type ProviderName = (typeof PROVIDER_NAMES)[number];
 
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'max' | 'xhigh' | 'ultra';
 
@@ -179,19 +184,9 @@ export type CodexProviderConfig = {
   config?: Record<string, CodexCliConfigValue>;
 };
 
-export type OpenRouterProviderConfig = {
-  baseUrl?: string;
-  model?: string;
-  referer?: string;
-  title?: string;
-  temperature?: number;
-  maxTokens?: number;
-};
-
 export type ProviderConfig = {
   name: ProviderName;
   codex?: CodexProviderConfig;
-  openrouter?: OpenRouterProviderConfig;
 };
 
 export type McpServerEntry = {

--- a/src/db.ts
+++ b/src/db.ts
@@ -292,6 +292,8 @@ export function backfillFtsIndex(): void {
   const indexLost = !sample?.n && ftsIndexedCount > 0;
   if (needsRebuild || (!sample?.n && !ftsMaxId) || indexLost) {
     if (indexLost) console.error('[db] FTS index is empty but was previously populated, rebuilding');
+    // reset first so an interrupted rebuild resumes from row zero
+    setMark(0, 0);
     // drop and recreate for clean rebuild
     d.exec('DROP TABLE IF EXISTS messages_fts');
     d.exec("CREATE VIRTUAL TABLE messages_fts USING fts5(text_content, content='', tokenize='porter unicode61')");

--- a/src/db.ts
+++ b/src/db.ts
@@ -257,53 +257,125 @@ export function backfillFtsIndex(): void {
   const currentVersion = versionRow ? parseInt(versionRow.value, 10) : 0;
   const needsRebuild = currentVersion < FTS_VERSION;
 
-  const sample = d.prepare("SELECT text_content FROM messages_fts LIMIT 1").get() as { text_content: string | null } | undefined;
+  // messages_fts is a contentless FTS5 table (content=''), so SQLite does not store the
+  // column values and reading one back always yields NULL no matter how many rows are
+  // indexed. Probing the column therefore reported "empty" on every start, forced a full
+  // rebuild each time and left the fts_version check above unreachable. Count rows.
+  const sample = d.prepare('SELECT COUNT(*) AS n FROM messages_fts').get() as { n: number } | undefined;
 
-  if (needsRebuild || !sample?.text_content) {
+  // High-water mark: the largest message id this index has already considered, indexed
+  // or not. Most messages extract to no searchable text at all (tool_use/tool_result
+  // blocks are stripped, and what is left is often under the 5 character floor), so they
+  // never get an FTS rowid. Without this mark the "missing from FTS" query re-selects
+  // every one of them on every launch forever. messages.id is AUTOINCREMENT, so ids are
+  // monotonic and are never reused even after a session delete, which is what makes a
+  // simple high-water mark safe here.
+  const markRow = d.prepare("SELECT value FROM db_meta WHERE key = 'fts_max_id'").get() as { value: string } | undefined;
+  const ftsMaxId = markRow ? parseInt(markRow.value, 10) || 0 : 0;
+  const countRow = d.prepare("SELECT value FROM db_meta WHERE key = 'fts_indexed_count'").get() as { value: string } | undefined;
+  const ftsIndexedCount = countRow ? parseInt(countRow.value, 10) || 0 : 0;
+  const setMark = (id: number, count: number) => {
+    d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_max_id', ?)").run(String(id));
+    d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_indexed_count', ?)").run(String(count));
+  };
+
+  // Decide whether the index is missing rather than merely empty. Skipping past a high
+  // water mark means a lost index can no longer heal itself the way the old rebuild-every
+  // -boot behaviour accidentally did, so the two cases have to be told apart:
+  //   never scanned            -> no mark, rebuild
+  //   scanned, indexed nothing -> legitimate on a history with no searchable text, skip
+  //   scanned, indexed rows, now empty -> index was lost or truncated, rebuild
+  const liveIndexCount = () => (d.prepare('SELECT COUNT(*) AS n FROM messages_fts').get() as { n: number }).n;
+  const highestConsideredId = () =>
+    (d.prepare("SELECT COALESCE(MAX(id), 0) AS n FROM messages WHERE type IN ('user', 'assistant')").get() as { n: number }).n;
+
+  const indexLost = !sample?.n && ftsIndexedCount > 0;
+  if (needsRebuild || (!sample?.n && !ftsMaxId) || indexLost) {
+    if (indexLost) console.error('[db] FTS index is empty but was previously populated, rebuilding');
     // drop and recreate for clean rebuild
     d.exec('DROP TABLE IF EXISTS messages_fts');
     d.exec("CREATE VIRTUAL TABLE messages_fts USING fts5(text_content, content='', tokenize='porter unicode61')");
 
     console.error(`[db] rebuilding FTS index (v${FTS_VERSION})...`);
-    const rows = d.prepare('SELECT id, content, type FROM messages WHERE type IN (\'user\', \'assistant\') ORDER BY id').all() as { id: number; content: string; type: string }[];
-
-    const insert = d.prepare('INSERT INTO messages_fts(rowid, text_content) VALUES (?, ?)');
-    const tx = d.transaction(() => {
-      let indexed = 0;
-      for (const row of rows) {
-        const text = extractMessageText(row.content);
-        if (!text || text.length < 5) continue;
-        insert.run(row.id, text);
-        indexed++;
-      }
-      d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_version', ?)").run(String(FTS_VERSION));
-      console.error(`[db] FTS rebuild complete (v${FTS_VERSION}): ${indexed}/${rows.length} messages indexed`);
-    });
-    tx();
+    const { indexed, maxId } = indexMessagesInPages(
+      "SELECT id, content FROM messages WHERE type IN ('user', 'assistant') AND id > ? ORDER BY id LIMIT ?"
+    );
+    void maxId;
+    setMark(highestConsideredId(), liveIndexCount());
+    d.prepare("INSERT OR REPLACE INTO db_meta (key, value) VALUES ('fts_version', ?)").run(String(FTS_VERSION));
+    console.error(`[db] FTS rebuild complete (v${FTS_VERSION}): ${indexed} messages indexed`);
     return;
   }
 
-  // incremental: index any messages missing from FTS (only user + assistant, skip result)
-  const missing = d.prepare(`
-    SELECT m.id, m.content, m.type FROM messages m
-    WHERE m.type IN ('user', 'assistant')
-      AND m.id NOT IN (SELECT rowid FROM messages_fts)
-    ORDER BY m.id
-  `).all() as { id: number; content: string; type: string }[];
+  // incremental: index any messages added since the high-water mark
+  const { indexed } = indexMessagesInPages(
+    `SELECT m.id, m.content FROM messages m
+     WHERE m.type IN ('user', 'assistant')
+       AND m.id > ?
+       AND m.id NOT IN (SELECT rowid FROM messages_fts)
+     ORDER BY m.id
+     LIMIT ?`,
+    2000,
+    ftsMaxId
+  );
 
-  if (missing.length === 0) return;
+  // Advance the mark to the highest id that now exists, not to the last row the query
+  // happened to return. Messages are already indexed on write by indexMessageForSearch,
+  // so the NOT IN filter usually excludes the newest rows entirely and the paging cursor
+  // never reaches them. Marking only what the filter returned would freeze the mark and
+  // leave every later message to be re-scanned on every start, which is the cost this
+  // mark exists to avoid. Everything up to here has now been considered either way.
+  // The count is read back live rather than accumulated: indexMessageForSearch writes
+  // rows without touching db_meta, so a running total drifts away from reality and the
+  // lost-index check above depends on this value being real.
+  const newMark = highestConsideredId();
+  if (newMark > ftsMaxId || liveIndexCount() !== ftsIndexedCount) setMark(newMark, liveIndexCount());
+  if (indexed > 0) {
+    console.error(`[db] incremental FTS backfill complete: ${indexed} messages indexed`);
+  }
+}
 
-  console.error(`[db] incremental FTS backfill: ${missing.length} messages to index...`);
+/**
+ * Index messages into messages_fts one bounded page at a time.
+ *
+ * pageSql must select id and content, take a keyset cursor as its first parameter and a
+ * page size as its second, and order by id. Paging keeps peak memory flat regardless of
+ * history size. The previous code materialised every user and assistant message in one
+ * .all(), which on a large database exhausted the V8 heap and crash-looped the gateway.
+ *
+ * This pages rather than streaming with .iterate() on purpose: better-sqlite3 refuses to
+ * run a write while an iterator is open on the same connection, throwing "This database
+ * connection is busy executing a query", so an open iterator plus batched inserts is not
+ * an option here.
+ */
+function indexMessagesInPages(
+  pageSql: string,
+  pageSize = 2000,
+  startAfterId = 0
+): { indexed: number; maxId: number } {
+  const d = getDb();
+  const page = d.prepare(pageSql);
   const insert = d.prepare('INSERT INTO messages_fts(rowid, text_content) VALUES (?, ?)');
-  const tx = d.transaction(() => {
-    let indexed = 0;
-    for (const row of missing) {
+
+  const writePage = d.transaction((rows: { id: number; content: string }[]): number => {
+    let n = 0;
+    for (const row of rows) {
       const text = extractMessageText(row.content);
       if (!text || text.length < 5) continue;
       insert.run(row.id, text);
-      indexed++;
+      n++;
     }
-    console.error(`[db] incremental FTS backfill complete: ${indexed}/${missing.length} messages indexed`);
+    return n;
   });
-  tx();
+
+  let cursor = startAfterId;
+  let indexed = 0;
+  for (;;) {
+    const rows = page.all(cursor, pageSize) as { id: number; content: string }[];
+    if (rows.length === 0) break;
+    indexed += writePage(rows);
+    cursor = rows[rows.length - 1].id;
+    if (rows.length < pageSize) break;
+  }
+  return { indexed, maxId: cursor };
 }

--- a/src/gateway/fs-watch-events.ts
+++ b/src/gateway/fs-watch-events.ts
@@ -1,0 +1,17 @@
+export type FsWatchEvent = {
+  eventType: string;
+  filename: string | null;
+};
+
+export function fsWatchDirectory(filename: string | null): string {
+  const rel = filename?.replace(/\\/g, '/') || '';
+  const lastSlash = rel.lastIndexOf('/');
+  return lastSlash > 0 ? rel.slice(0, lastSlash) : '';
+}
+
+export function rememberFsWatchEvent(
+  pending: Map<string, FsWatchEvent>,
+  event: FsWatchEvent,
+): void {
+  pending.set(fsWatchDirectory(event.filename), event);
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -883,7 +883,13 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
     }
 
     try {
-      const watcher = watch(resolved, { recursive: false }, (eventType, filename) => {
+      // Recursive: the explorer renders an expandable tree, so a change anywhere
+      // under the open root is visible to the user. Watching only the top level
+      // meant edits, creations and deletions inside any subdirectory produced no
+      // event at all and the tree silently went stale. On macOS this is backed by
+      // FSEvents, and events are debounced below, so the cost is a coalesced
+      // notification rather than one per file.
+      const watcher = watch(resolved, { recursive: true }, (eventType, filename) => {
         const entry = fileWatchers.get(resolved);
         if (!entry) return;
         const filenameStr = filename ? String(filename) : null;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -906,6 +906,7 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
       console.log(`[gateway] started watching: ${resolved}`);
     } catch (err) {
       console.error(`[gateway] failed to watch ${resolved}:`, err);
+      throw err;
     }
   };
 
@@ -5535,8 +5536,12 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
           }
           const tracked = clientWs ? watchedPathsByClient.get(clientWs) : undefined;
           if (!tracked?.has(resolvedWatch)) {
-            startWatching(resolvedWatch);
-            tracked?.add(resolvedWatch);
+            try {
+              startWatching(resolvedWatch);
+              tracked?.add(resolvedWatch);
+            } catch (err) {
+              return { id, error: err instanceof Error ? err.message : String(err) };
+            }
           }
           return { id, result: { watching: resolvedWatch } };
         }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -43,6 +43,7 @@ import { getDb } from '../db.js';
 import { insertEvent, queryEventsBySessionCursor, deleteEventsUpToSeq, cleanupOldEvents } from './event-log.js';
 import { getChannelHandler } from '../tools/messaging.js';
 import { closeBrowser } from '../browser/manager.js';
+import { rememberFsWatchEvent, type FsWatchEvent } from './fs-watch-events.js';
 import { setScheduler, setBrowserConfig } from '../tools/index.js';
 import { loadProjects, saveProjects, type Project } from '../tools/projects.js';
 import {
@@ -734,7 +735,7 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
     watcher: FSWatcher;
     refCount: number;
     debounceTimer?: ReturnType<typeof setTimeout>;
-    pendingEvent?: { eventType: string; filename: string | null };
+    pendingEvents?: Map<string, FsWatchEvent>;
   };
   const fileWatchers = new Map<string, FileWatchEntry>();
   const watchedPathsByClient = new Map<WebSocket, Set<string>>();
@@ -864,13 +865,15 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
     const entry = fileWatchers.get(resolved);
     if (!entry) return;
     entry.debounceTimer = undefined;
-    const pending = entry.pendingEvent;
-    entry.pendingEvent = undefined;
+    const pending = entry.pendingEvents;
+    entry.pendingEvents = undefined;
     if (!pending) return;
-    broadcast({
-      event: 'fs.change',
-      data: { path: resolved, eventType: pending.eventType, filename: pending.filename, timestamp: Date.now() },
-    });
+    for (const event of pending.values()) {
+      broadcast({
+        event: 'fs.change',
+        data: { path: resolved, eventType: event.eventType, filename: event.filename, timestamp: Date.now() },
+      });
+    }
   };
 
   const startWatching = (path: string) => {
@@ -896,7 +899,8 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
         if (DEBUG_FS_WATCH) {
           console.log(`[gateway] fs.watch: ${eventType} in ${resolved}${filenameStr ? '/' + filenameStr : ''}`);
         }
-        entry.pendingEvent = { eventType, filename: filenameStr };
+        if (!entry.pendingEvents) entry.pendingEvents = new Map();
+        rememberFsWatchEvent(entry.pendingEvents, { eventType, filename: filenameStr });
         if (entry.debounceTimer) return;
         entry.debounceTimer = setTimeout(() => emitFsWatchEvent(resolved), FS_WATCH_DEBOUNCE_MS);
         entry.debounceTimer.unref?.();

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -22,7 +22,7 @@ const resolve = (p: string, base?: string) => {
 };
 import { moveToTrash, copyPath, movePath, isInside } from './fs-ops.js';
 import type { Config } from '../config.js';
-import { isPathAllowed, saveConfig, ALWAYS_DENIED, type SecurityConfig, type ToolPolicyConfig } from '../config.js';
+import { isPathAllowed, saveConfig, ALWAYS_DENIED, PROVIDER_NAMES, type SecurityConfig, type ToolPolicyConfig } from '../config.js';
 import type { WsMessage, WsResponse, WsEvent, GatewayContext } from './types.js';
 import { SessionRegistry } from './session-registry.js';
 import { ChannelManager } from './channel-manager.js';
@@ -5054,8 +5054,8 @@ export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
 
           // provider config keys
           if (key === 'provider.name' && typeof value === 'string') {
-            if (!['claude', 'codex', 'minimax'].includes(value)) {
-              return { id, error: 'provider.name must be "claude", "codex", or "minimax"' };
+            if (!(PROVIDER_NAMES as readonly string[]).includes(value)) {
+              return { id, error: `provider.name must be one of: ${PROVIDER_NAMES.join(', ')}` };
             }
             config.provider.name = value as ProviderName;
             saveConfig(config);

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -6,6 +6,7 @@ import { dirname } from 'node:path';
 import type { Provider, ProviderRunOptions, ProviderMessage, ProviderAuthStatus, ProviderQueryResult, RunHandle } from './types.js';
 import { guardImages } from './image-guard.js';
 import { DORABOT_DIR, CLAUDE_KEY_PATH, CLAUDE_OAUTH_PATH } from '../workspace.js';
+import { cleanEnvForSdk } from '../sdk-env.js';
 import { getSecretStorageBackend, keychainDelete, keychainLoad, keychainStore, type SecretStorageBackend } from '../auth/keychain.js';
 
 // ── Node binary resolution ──────────────────────────────────────────
@@ -362,6 +363,44 @@ function scheduleTokenRefresh(tokens: OAuthTokens, retryDelayMs?: number): void 
     scheduleTokenRefresh(latest, backoff);
   }, delay);
   refreshTimer.unref?.();
+}
+
+/**
+ * Write the credential for `method` into an env object destined for an SDK
+ * subprocess, clearing the competing one so behaviour does not depend on a
+ * precedence order that lives in the CLI binary rather than the SDK.
+ *
+ * Shared by query() and verifyAuth() on purpose. verifyAuth() used to call the
+ * SDK with no env at all, so it inherited process.env while real runs received
+ * the cached login-shell snapshot. It could therefore pass against a credential
+ * that no real session would ever see, and report healthy while every chat
+ * failed. A health check has to exercise the same path as the thing it checks.
+ */
+function applyAuthEnv(env: Record<string, string>, method: AuthMethod, freshToken?: string | null): void {
+  if (method === 'api_key') {
+    const key = getApiKey();
+    if (key) env.ANTHROPIC_API_KEY = key;
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    return;
+  }
+  if (method === 'dorabot_oauth') {
+    // Prefer the freshly ensured token, but fall back to whatever is stored rather than
+    // unsetting: a refresh that failed on a network blip does not invalidate an access
+    // token that still has time left on it.
+    const token = freshToken || loadOAuthTokens()?.access_token;
+    if (token) env.CLAUDE_CODE_OAUTH_TOKEN = token;
+    else delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete env.ANTHROPIC_API_KEY;
+    return;
+  }
+  if (method === 'cli_keychain') {
+    // The CLI owns and refreshes this credential. Deliberately do not override it with
+    // dorabot's token: they can be different accounts, and silently switching which one
+    // is billed is worse than the expiry it would fix. Only clear the snapshot's token,
+    // which was captured at startup and is stale by definition, so it cannot shadow the
+    // keychain.
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  }
 }
 
 /** Ensure we have a valid access token, refreshing if needed. Sets CLAUDE_CODE_OAUTH_TOKEN env. */
@@ -727,6 +766,14 @@ export class ClaudeProvider implements Provider {
         await ensureOAuthToken();
       }
 
+      // Build the env exactly as a real run does, then apply the same credential
+      // selection. Calling the SDK bare here meant this check ran against a different
+      // environment than every actual session, which is how it could pass while chats
+      // were failing.
+      const verifyEnv = cleanEnvForSdk();
+      if (method === 'dorabot_oauth') await ensureOAuthToken();
+      applyAuthEnv(verifyEnv, method);
+
       const stream = query({
         prompt: "Reply with only the word 'ok'",
         options: {
@@ -734,6 +781,7 @@ export class ClaudeProvider implements Provider {
           maxTurns: 1,
           allowedTools: [],
           abortController,
+          env: verifyEnv,
         },
       });
 
@@ -828,29 +876,7 @@ export class ClaudeProvider implements Provider {
     //
     // opts.env is rebuilt per run (mergeSkillEnv returns a fresh object), so mutating it
     // here cannot leak into the cached snapshot or into another run.
-    if (opts.env) {
-      if (method === 'api_key') {
-        const key = getApiKey();
-        if (key) opts.env.ANTHROPIC_API_KEY = key;
-        // A stale OAuth token in the snapshot must not compete with the chosen key.
-        delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
-      } else if (method === 'dorabot_oauth') {
-        // Prefer the freshly ensured token, but fall back to whatever is stored rather
-        // than unsetting: a refresh that failed on a network blip does not invalidate an
-        // access token that still has time left on it.
-        const token = freshOAuthToken || loadOAuthTokens()?.access_token;
-        if (token) opts.env.CLAUDE_CODE_OAUTH_TOKEN = token;
-        else delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
-        delete opts.env.ANTHROPIC_API_KEY;
-      } else if (method === 'cli_keychain') {
-        // The CLI has its own credential and refreshes it itself. Deliberately do not
-        // override it with dorabot's token: the two can be different accounts, and
-        // silently switching which one is billed is worse than the expiry it would fix.
-        // Always clear the snapshot's token so it cannot shadow the keychain: whatever
-        // it holds was captured at startup and is stale by definition.
-        delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
-      }
-    }
+    if (opts.env) applyAuthEnv(opts.env, method, freshOAuthToken);
 
     // ── Async generator message feed (buffett pattern) ──────────────
     // Instead of passing a string prompt to query(), we create an async

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -8,6 +8,7 @@ import { guardImages } from './image-guard.js';
 import { DORABOT_DIR, CLAUDE_KEY_PATH, CLAUDE_OAUTH_PATH } from '../workspace.js';
 import { cleanEnvForSdk } from '../sdk-env.js';
 import { getSecretStorageBackend, keychainDelete, keychainLoad, keychainStore, type SecretStorageBackend } from '../auth/keychain.js';
+import { canReuseAccessTokenAfterRefreshFailure } from './oauth-refresh.js';
 
 // ── Node binary resolution ──────────────────────────────────────────
 // Electron apps get a minimal PATH. Resolve the full path to node once at startup
@@ -261,7 +262,7 @@ async function refreshAccessToken(refreshToken: string): Promise<OAuthTokens | n
     });
     if (!res.ok) {
       console.error(`[claude] token refresh failed: ${res.status}`);
-      lastRefreshRejected = true;
+      lastRefreshRejected = res.status === 400 || res.status === 401 || res.status === 403;
       return null;
     }
     lastRefreshRejected = false;
@@ -351,14 +352,12 @@ function scheduleTokenRefresh(tokens: OAuthTokens, retryDelayMs?: number): void 
     console.log(
       `[claude] token refresh failed (attempt ${refreshFailureStreak}), retrying in ${Math.round(backoff / 1000)}s`,
     );
-    // Only tell the user when it looks like a credential problem, or when we have been
-    // failing long enough that the backoff has reached its ceiling. Offline stretches
-    // stay silent and recover by themselves.
+    // only rejected credentials require reconnect
     if (lastRefreshRejected && refreshFailureStreak >= 3) {
       emitAuthRequired('OAuth refresh rejected, still retrying in background');
     } else if (backoff >= REFRESH_RETRY_MAX_MS && !refreshCapNotified) {
       refreshCapNotified = true;
-      emitAuthRequired('OAuth refresh has been failing, still retrying in background');
+      console.warn('[claude] OAuth refresh is still unavailable; background retries will continue');
     }
     scheduleTokenRefresh(latest, backoff);
   }, delay);
@@ -384,10 +383,10 @@ function applyAuthEnv(env: Record<string, string>, method: AuthMethod, freshToke
     return;
   }
   if (method === 'dorabot_oauth') {
-    // Prefer the freshly ensured token, but fall back to whatever is stored rather than
-    // unsetting: a refresh that failed on a network blip does not invalidate an access
-    // token that still has time left on it.
-    const token = freshToken || loadOAuthTokens()?.access_token;
+    const stored = loadOAuthTokens();
+    const token = freshToken || (stored && Date.now() < stored.expires_at
+      ? stored.access_token
+      : undefined);
     if (token) env.CLAUDE_CODE_OAUTH_TOKEN = token;
     else delete env.CLAUDE_CODE_OAUTH_TOKEN;
     delete env.ANTHROPIC_API_KEY;
@@ -396,10 +395,10 @@ function applyAuthEnv(env: Record<string, string>, method: AuthMethod, freshToke
   if (method === 'cli_keychain') {
     // The CLI owns and refreshes this credential. Deliberately do not override it with
     // dorabot's token: they can be different accounts, and silently switching which one
-    // is billed is worse than the expiry it would fix. Only clear the snapshot's token,
-    // which was captured at startup and is stale by definition, so it cannot shadow the
-    // keychain.
+    // is billed is worse than the expiry it would fix. Clear snapshot credentials so
+    // they cannot shadow the keychain.
     delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete env.ANTHROPIC_API_KEY;
   }
 }
 
@@ -421,6 +420,10 @@ async function ensureOAuthToken(): Promise<string | null> {
       // cycles, and incrementing it per turn pins the backoff at its ceiling, which
       // makes recovery slower the more the user types.
       if (!refreshTimer) scheduleTokenRefresh(tokens, REFRESH_RETRY_BASE_MS);
+      if (canReuseAccessTokenAfterRefreshFailure(tokens.expires_at, lastRefreshRejected)) {
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = tokens.access_token;
+        return tokens.access_token;
+      }
       return null;
     }
     refreshFailureStreak = 0;
@@ -591,15 +594,17 @@ export class ClaudeProvider implements Provider {
           };
           return this._cachedAuth;
         }
-        // token expired and refresh failed — needs re-auth
+        const needsReconnect = tokenState.reconnectRequired;
         return {
           authenticated: false,
           method: 'oauth',
-          error: 'OAuth token expired. Re-authentication required.',
+          error: needsReconnect
+            ? 'OAuth token expired. Re-authentication required.'
+            : 'OAuth token refresh is temporarily unavailable.',
           storageBackend: tokenState.storageBackend,
           tokenHealth: tokenState.tokenHealth,
           nextRefreshAt: tokenState.nextRefreshAt,
-          reconnectRequired: true,
+          reconnectRequired: needsReconnect,
         };
       }
       default:
@@ -760,19 +765,17 @@ export class ClaudeProvider implements Provider {
     const timeout = setTimeout(() => abortController.abort(), 30_000);
 
     try {
-      // Ensure OAuth token is fresh
       const method = getActiveAuthMethod();
-      if (method === 'dorabot_oauth') {
-        await ensureOAuthToken();
-      }
+      const oauthToken = method === 'dorabot_oauth'
+        ? await ensureOAuthToken()
+        : null;
 
       // Build the env exactly as a real run does, then apply the same credential
       // selection. Calling the SDK bare here meant this check ran against a different
       // environment than every actual session, which is how it could pass while chats
       // were failing.
       const verifyEnv = cleanEnvForSdk();
-      if (method === 'dorabot_oauth') await ensureOAuthToken();
-      applyAuthEnv(verifyEnv, method);
+      applyAuthEnv(verifyEnv, method, oauthToken);
 
       const stream = query({
         prompt: "Reply with only the word 'ok'",

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -145,6 +145,16 @@ type OAuthTokens = {
 let nextRefreshAt: number | null = null;
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectRequired = false;
+// Consecutive refresh failures. Drives the retry backoff; reset on any success.
+let refreshFailureStreak = 0;
+// Whether the last refresh failure came from the token endpoint rejecting us rather than
+// from the request never reaching it. Only a rejection is evidence of an auth problem.
+let lastRefreshRejected = false;
+// Set once per outage when the backoff first reaches its ceiling, so a long offline
+// stretch surfaces one notification rather than one per retry. Cleared on success.
+let refreshCapNotified = false;
+const REFRESH_RETRY_BASE_MS = 30_000;
+const REFRESH_RETRY_MAX_MS = 10 * 60 * 1000;
 let lastAuthRequiredEmit = 0;
 const AUTH_REQUIRED_COOLDOWN_MS = 60_000;
 const authRequiredListeners = new Set<(reason: string) => void>();
@@ -250,8 +260,10 @@ async function refreshAccessToken(refreshToken: string): Promise<OAuthTokens | n
     });
     if (!res.ok) {
       console.error(`[claude] token refresh failed: ${res.status}`);
+      lastRefreshRejected = true;
       return null;
     }
+    lastRefreshRejected = false;
     const data = await res.json() as { access_token: string; refresh_token?: string; expires_in?: number };
     const tokens: OAuthTokens = {
       access_token: data.access_token,
@@ -262,19 +274,48 @@ async function refreshAccessToken(refreshToken: string): Promise<OAuthTokens | n
     reconnectRequired = false;
     return tokens;
   } catch (err) {
+    // Network-class failure (offline, DNS not up yet after a wake, captive portal). This
+    // is not an auth problem and must not raise authRequired: the retry schedule will
+    // recover on its own, and raising it here means a desktop notification and sound
+    // every time a sleeping machine wakes without a network.
     console.error('[claude] token refresh error:', err);
-    emitAuthRequired('OAuth refresh failed');
+    lastRefreshRejected = false;
     return null;
   }
 }
 
-function scheduleTokenRefresh(tokens: OAuthTokens): void {
+// Single-flight refresh. The token endpoint rotates the refresh_token, so a
+// second concurrent POST carrying the same one is rejected with 400. Without
+// this, a chat turn and a subagent turn starting together race and one of them
+// permanently poisons the stored credential.
+let inflightRefresh: Promise<OAuthTokens | null> | null = null;
+
+function refreshAccessTokenShared(refreshToken: string): Promise<OAuthTokens | null> {
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = refreshAccessToken(refreshToken).finally(() => {
+    inflightRefresh = null;
+  });
+  return inflightRefresh;
+}
+
+/**
+ * Arm the next token refresh.
+ *
+ * Pass `retryDelayMs` to re-arm after a failure instead of scheduling off the
+ * token's expiry. A refresh failure must never leave the process with no timer
+ * armed: the common causes are transient (DNS is not up yet on wake from sleep,
+ * captive portal, brief offline) and recovering from them used to require the
+ * user to quit and relaunch the app.
+ */
+function scheduleTokenRefresh(tokens: OAuthTokens, retryDelayMs?: number): void {
   if (refreshTimer) {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
 
-  const runAt = Math.max(Date.now() + 1_000, tokens.expires_at - REFRESH_LEAD_MS);
+  const runAt = retryDelayMs !== undefined
+    ? Date.now() + retryDelayMs
+    : Math.max(Date.now() + 1_000, tokens.expires_at - REFRESH_LEAD_MS);
   nextRefreshAt = runAt;
   const delay = runAt - Date.now();
   refreshTimer = setTimeout(async () => {
@@ -285,23 +326,40 @@ function scheduleTokenRefresh(tokens: OAuthTokens): void {
       nextRefreshAt = null;
       return;
     }
-    // Retry refresh up to 3 times with exponential backoff
-    let refreshed: OAuthTokens | null = null;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      refreshed = await refreshAccessToken(latest.refresh_token);
-      if (refreshed) break;
-      if (attempt < 2) {
-        const backoff = (attempt + 1) * 5_000; // 5s, 10s
-        console.log(`[claude] token refresh attempt ${attempt + 1} failed, retrying in ${backoff / 1000}s...`);
-        await new Promise(r => setTimeout(r, backoff));
-      }
-    }
-    if (!refreshed) {
-      emitAuthRequired('OAuth refresh failed after retries');
-      nextRefreshAt = null;
+    // ensureOAuthToken() may have refreshed while this timer was pending.
+    if (tokenHealth(latest) === 'valid') {
+      refreshFailureStreak = 0;
+      refreshCapNotified = false;
+      scheduleTokenRefresh(latest);
       return;
     }
-    scheduleTokenRefresh(refreshed);
+    const refreshed = await refreshAccessTokenShared(latest.refresh_token);
+    if (refreshed) {
+      refreshFailureStreak = 0;
+      refreshCapNotified = false;
+      scheduleTokenRefresh(refreshed);
+      return;
+    }
+    // Keep trying. The refresh token outlives the access token, so a failure
+    // here is almost always the network rather than a dead credential.
+    refreshFailureStreak++;
+    const backoff = Math.min(
+      REFRESH_RETRY_BASE_MS * 2 ** (refreshFailureStreak - 1),
+      REFRESH_RETRY_MAX_MS,
+    );
+    console.log(
+      `[claude] token refresh failed (attempt ${refreshFailureStreak}), retrying in ${Math.round(backoff / 1000)}s`,
+    );
+    // Only tell the user when it looks like a credential problem, or when we have been
+    // failing long enough that the backoff has reached its ceiling. Offline stretches
+    // stay silent and recover by themselves.
+    if (lastRefreshRejected && refreshFailureStreak >= 3) {
+      emitAuthRequired('OAuth refresh rejected, still retrying in background');
+    } else if (backoff >= REFRESH_RETRY_MAX_MS && !refreshCapNotified) {
+      refreshCapNotified = true;
+      emitAuthRequired('OAuth refresh has been failing, still retrying in background');
+    }
+    scheduleTokenRefresh(latest, backoff);
   }, delay);
   refreshTimer.unref?.();
 }
@@ -313,11 +371,21 @@ async function ensureOAuthToken(): Promise<string | null> {
 
   if (Date.now() > tokens.expires_at - 300_000) {
     console.log('[claude] access token expired or expiring, refreshing...');
-    const refreshed = await refreshAccessToken(tokens.refresh_token);
+    const refreshed = await refreshAccessTokenShared(tokens.refresh_token);
     if (!refreshed) {
-      emitAuthRequired('OAuth token expired');
+      if (lastRefreshRejected) emitAuthRequired('OAuth token expired');
+      // Arm a background retry so recovery does not require an app restart, but only
+      // if nothing is armed already. This runs at the top of every turn, so re-arming
+      // unconditionally would clear the pending retry each time a user sends a message
+      // and the background timer would never fire while they are actively chatting.
+      // The streak is deliberately not touched here: it counts consecutive retry
+      // cycles, and incrementing it per turn pins the backoff at its ceiling, which
+      // makes recovery slower the more the user types.
+      if (!refreshTimer) scheduleTokenRefresh(tokens, REFRESH_RETRY_BASE_MS);
       return null;
     }
+    refreshFailureStreak = 0;
+    refreshCapNotified = false;
     scheduleTokenRefresh(refreshed);
     process.env.CLAUDE_CODE_OAUTH_TOKEN = refreshed.access_token;
     return refreshed.access_token;
@@ -741,8 +809,47 @@ export class ClaudeProvider implements Provider {
   async *query(opts: ProviderRunOptions): AsyncGenerator<ProviderMessage, ProviderQueryResult, unknown> {
     // refresh env token for dorabot_oauth only (cli_keychain handles its own)
     const method = getActiveAuthMethod();
+    let freshOAuthToken: string | null = null;
     if (method === 'dorabot_oauth') {
-      await ensureOAuthToken();
+      freshOAuthToken = await ensureOAuthToken();
+    }
+
+    // Put the current credential into the env the SDK will actually spawn with.
+    //
+    // The SDK does not merge options.env with process.env, it replaces it
+    // (`env: c = {...process.env}` is a destructuring default, so passing env wins
+    // outright). opts.env comes from cleanEnvForSdk(), which snapshots a login shell
+    // once and caches it for the life of the process. That snapshot inherits whatever
+    // process.env held at the time, so it captures the token from gateway startup and
+    // then never changes. Everything this file does with process.env after a refresh is
+    // therefore invisible to the CLI subprocess, which keeps using the startup token
+    // until it expires and every request begins failing. Restarting the app is the only
+    // thing that reloads it, which is exactly the reported symptom.
+    //
+    // opts.env is rebuilt per run (mergeSkillEnv returns a fresh object), so mutating it
+    // here cannot leak into the cached snapshot or into another run.
+    if (opts.env) {
+      if (method === 'api_key') {
+        const key = getApiKey();
+        if (key) opts.env.ANTHROPIC_API_KEY = key;
+        // A stale OAuth token in the snapshot must not compete with the chosen key.
+        delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
+      } else if (method === 'dorabot_oauth') {
+        // Prefer the freshly ensured token, but fall back to whatever is stored rather
+        // than unsetting: a refresh that failed on a network blip does not invalidate an
+        // access token that still has time left on it.
+        const token = freshOAuthToken || loadOAuthTokens()?.access_token;
+        if (token) opts.env.CLAUDE_CODE_OAUTH_TOKEN = token;
+        else delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
+        delete opts.env.ANTHROPIC_API_KEY;
+      } else if (method === 'cli_keychain') {
+        // The CLI has its own credential and refreshes it itself. Deliberately do not
+        // override it with dorabot's token: the two can be different accounts, and
+        // silently switching which one is billed is worse than the expiry it would fix.
+        // Always clear the snapshot's token so it cannot shadow the keychain: whatever
+        // it holds was captured at startup and is stale by definition.
+        delete opts.env.CLAUDE_CODE_OAUTH_TOKEN;
+      }
     }
 
     // ── Async generator message feed (buffett pattern) ──────────────

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -11,6 +11,7 @@ import { DORABOT_DIR, CODEX_OAUTH_PATH, OPENAI_KEY_PATH, TMP_DIR } from '../work
 import { getSecretStorageBackend, keychainDelete, keychainLoad, keychainStore, type SecretStorageBackend } from '../auth/keychain.js';
 import { guardImages } from './image-guard.js';
 import { isLoggedInCodexStatusText, summarizeCodexCliAuthRecord } from './codex-auth-state.js';
+import { canReuseAccessTokenAfterRefreshFailure } from './oauth-refresh.js';
 import { mergeSkillEnv } from '../skills/env.js';
 
 // ── OAuth constants (same client as Codex CLI) ──────────────────────
@@ -1223,7 +1224,7 @@ async function refreshCodexAccessToken(refreshToken: string, previousIdToken?: s
     });
     if (!res.ok) {
       console.error(`[codex] token refresh failed: ${res.status}`);
-      lastRefreshRejected = true;
+      lastRefreshRejected = res.status === 400 || res.status === 401 || res.status === 403;
       return null;
     }
     lastRefreshRejected = false;
@@ -1319,7 +1320,7 @@ function scheduleCodexRefresh(tokens: CodexOAuthTokens, retryDelayMs?: number): 
       emitAuthRequired('OAuth refresh rejected, still retrying in background');
     } else if (backoff >= REFRESH_RETRY_MAX_MS && !refreshCapNotified) {
       refreshCapNotified = true;
-      emitAuthRequired('OAuth refresh has been failing, still retrying in background');
+      console.warn('[codex] OAuth refresh is still unavailable; background retries will continue');
     }
     scheduleCodexRefresh(latest, backoff);
   }, delay);
@@ -1327,11 +1328,11 @@ function scheduleCodexRefresh(tokens: CodexOAuthTokens, retryDelayMs?: number): 
 }
 
 /** Ensure we have a valid access token, refreshing if needed */
-async function ensureCodexOAuthToken(): Promise<string | null> {
+async function ensureCodexOAuthToken(forceRefresh = false): Promise<string | null> {
   const tokens = loadCodexOAuthTokens();
   if (!tokens) return null;
 
-  if (Date.now() > tokens.expires_at - 300_000) {
+  if (forceRefresh || Date.now() > tokens.expires_at - 300_000) {
     console.log('[codex] access token expiring, refreshing...');
     const refreshed = await refreshCodexAccessTokenShared(tokens.refresh_token, tokens.id_token);
     if (!refreshed) {
@@ -1341,6 +1342,13 @@ async function ensureCodexOAuthToken(): Promise<string | null> {
       // the background timer would never fire while the user is active. The streak is
       // deliberately untouched: it counts retry cycles, not turns.
       if (!refreshTimer) scheduleCodexRefresh(tokens, REFRESH_RETRY_BASE_MS);
+      if (canReuseAccessTokenAfterRefreshFailure(
+        tokens.expires_at,
+        lastRefreshRejected,
+        forceRefresh,
+      )) {
+        return tokens.access_token;
+      }
       return null;
     }
     refreshFailureStreak = 0;
@@ -1450,6 +1458,20 @@ async function resolveCodexAuthState(): Promise<{ apiKey?: string; status: Provi
         },
       };
     }
+    const needsReconnect = reconnectRequired;
+    return {
+      status: {
+        authenticated: false,
+        method: 'oauth',
+        error: needsReconnect
+          ? 'OAuth token expired. Reconnect required.'
+          : 'OAuth token refresh is temporarily unavailable.',
+        storageBackend,
+        tokenHealth: tokenHealth(latest),
+        nextRefreshAt: nextRefreshAt || undefined,
+        reconnectRequired: needsReconnect,
+      },
+    };
   }
 
   const cliAuth = await getCodexCliAuthStatus();
@@ -1461,21 +1483,6 @@ async function resolveCodexAuthState(): Promise<{ apiKey?: string; status: Provi
         identity: cliAuth.identity,
         storageBackend: cliAuth.storageBackend,
         tokenHealth: 'valid',
-      },
-    };
-  }
-
-  if (oauthTokens) {
-    const latest = loadCodexOAuthTokens() || oauthTokens;
-    return {
-      status: {
-        authenticated: false,
-        method: 'oauth',
-        error: 'OAuth token expired. Reconnect required.',
-        storageBackend,
-        tokenHealth: tokenHealth(latest),
-        nextRefreshAt: nextRefreshAt || undefined,
-        reconnectRequired: true,
       },
     };
   }
@@ -1709,7 +1716,7 @@ async function handleCodexServerRequest(message: JsonRpcResponse, opts: Provider
   }
 
   if (method === 'account/chatgptAuthTokens/refresh') {
-    const accessToken = await ensureCodexOAuthToken();
+    const accessToken = await ensureCodexOAuthToken(true);
     const latest = loadCodexOAuthTokens();
     if (!accessToken || !latest) throw new Error('No ChatGPT OAuth token available');
     return {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -941,6 +941,12 @@ type CodexCliAuthStatus = {
 
 let nextRefreshAt: number | null = null;
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+// Retry state for token refresh, mirroring claude.ts.
+let refreshFailureStreak = 0;
+let lastRefreshRejected = false;
+let refreshCapNotified = false;
+const REFRESH_RETRY_BASE_MS = 30_000;
+const REFRESH_RETRY_MAX_MS = 10 * 60 * 1000;
 let reconnectRequired = false;
 let lastAuthRequiredEmit = 0;
 const AUTH_REQUIRED_COOLDOWN_MS = 60_000;
@@ -1217,8 +1223,10 @@ async function refreshCodexAccessToken(refreshToken: string, previousIdToken?: s
     });
     if (!res.ok) {
       console.error(`[codex] token refresh failed: ${res.status}`);
+      lastRefreshRejected = true;
       return null;
     }
+    lastRefreshRejected = false;
     const data = await res.json() as { access_token: string; refresh_token: string; expires_in: number; id_token?: string };
     if (!data.access_token || !data.refresh_token) return null;
     const accountId = getAccountId(data.access_token);
@@ -1231,19 +1239,48 @@ async function refreshCodexAccessToken(refreshToken: string, previousIdToken?: s
       ...(data.id_token || previousIdToken ? { id_token: data.id_token || previousIdToken } : {}),
     };
   } catch (err) {
+    // Network-class failure, not an auth problem. See the matching note in claude.ts:
+    // raising authRequired here means a notification every time a sleeping machine wakes
+    // before its network is up.
     console.error('[codex] token refresh error:', err);
-    emitAuthRequired('OAuth refresh failed');
+    lastRefreshRejected = false;
     return null;
   }
 }
 
-function scheduleCodexRefresh(tokens: CodexOAuthTokens): void {
+// Single-flight, mirroring claude.ts. Codex rotates refresh_token on every response (the
+// parse above rejects a response without one), so two concurrent refreshes carrying the
+// same token guarantee that one of them is rejected. Persisting inside the wrapper keeps
+// that write on exactly one path.
+let inflightCodexRefresh: Promise<CodexOAuthTokens | null> | null = null;
+
+function refreshCodexAccessTokenShared(refreshToken: string, previousIdToken?: string): Promise<CodexOAuthTokens | null> {
+  if (inflightCodexRefresh) return inflightCodexRefresh;
+  inflightCodexRefresh = refreshCodexAccessToken(refreshToken, previousIdToken)
+    .then((tokens) => {
+      if (tokens) persistCodexOAuthTokens(tokens);
+      return tokens;
+    })
+    .finally(() => {
+      inflightCodexRefresh = null;
+    });
+  return inflightCodexRefresh;
+}
+
+/**
+ * Arm the next Codex token refresh. Pass `retryDelayMs` to re-arm after a failure rather
+ * than scheduling off the token's expiry, so a failed refresh never leaves the process
+ * with no timer armed.
+ */
+function scheduleCodexRefresh(tokens: CodexOAuthTokens, retryDelayMs?: number): void {
   if (refreshTimer) {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
 
-  const runAt = Math.max(Date.now() + 1_000, tokens.expires_at - REFRESH_LEAD_MS);
+  const runAt = retryDelayMs !== undefined
+    ? Date.now() + retryDelayMs
+    : Math.max(Date.now() + 1_000, tokens.expires_at - REFRESH_LEAD_MS);
   nextRefreshAt = runAt;
   const delay = runAt - Date.now();
   refreshTimer = setTimeout(async () => {
@@ -1254,24 +1291,37 @@ function scheduleCodexRefresh(tokens: CodexOAuthTokens): void {
       nextRefreshAt = null;
       return;
     }
-    // Retry refresh up to 3 times with exponential backoff
-    let refreshed: CodexOAuthTokens | null = null;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      refreshed = await refreshCodexAccessToken(latest.refresh_token, latest.id_token);
-      if (refreshed) break;
-      if (attempt < 2) {
-        const backoff = (attempt + 1) * 5_000;
-        console.log(`[codex] token refresh attempt ${attempt + 1} failed, retrying in ${backoff / 1000}s...`);
-        await new Promise(r => setTimeout(r, backoff));
-      }
-    }
-    if (!refreshed) {
-      emitAuthRequired('OAuth refresh failed after retries');
-      nextRefreshAt = null;
+    // ensureCodexOAuthToken() may have refreshed while this timer was pending.
+    if (tokenHealth(latest) === 'valid') {
+      refreshFailureStreak = 0;
+      refreshCapNotified = false;
+      scheduleCodexRefresh(latest);
       return;
     }
-    persistCodexOAuthTokens(refreshed);
-    scheduleCodexRefresh(refreshed);
+    const refreshed = await refreshCodexAccessTokenShared(latest.refresh_token, latest.id_token);
+    if (refreshed) {
+      refreshFailureStreak = 0;
+      refreshCapNotified = false;
+      scheduleCodexRefresh(refreshed);
+      return;
+    }
+    // Keep trying. The refresh token outlives the access token, so a failure here is
+    // almost always the network rather than a dead credential.
+    refreshFailureStreak++;
+    const backoff = Math.min(
+      REFRESH_RETRY_BASE_MS * 2 ** (refreshFailureStreak - 1),
+      REFRESH_RETRY_MAX_MS,
+    );
+    console.log(
+      `[codex] token refresh failed (attempt ${refreshFailureStreak}), retrying in ${Math.round(backoff / 1000)}s`,
+    );
+    if (lastRefreshRejected && refreshFailureStreak >= 3) {
+      emitAuthRequired('OAuth refresh rejected, still retrying in background');
+    } else if (backoff >= REFRESH_RETRY_MAX_MS && !refreshCapNotified) {
+      refreshCapNotified = true;
+      emitAuthRequired('OAuth refresh has been failing, still retrying in background');
+    }
+    scheduleCodexRefresh(latest, backoff);
   }, delay);
   refreshTimer.unref?.();
 }
@@ -1283,12 +1333,18 @@ async function ensureCodexOAuthToken(): Promise<string | null> {
 
   if (Date.now() > tokens.expires_at - 300_000) {
     console.log('[codex] access token expiring, refreshing...');
-    const refreshed = await refreshCodexAccessToken(tokens.refresh_token, tokens.id_token);
+    const refreshed = await refreshCodexAccessTokenShared(tokens.refresh_token, tokens.id_token);
     if (!refreshed) {
-      emitAuthRequired('OAuth token expired');
+      if (lastRefreshRejected) emitAuthRequired('OAuth token expired');
+      // Arm a background retry only if nothing is armed. This runs at the top of every
+      // turn, so re-arming unconditionally would clear the pending retry each time and
+      // the background timer would never fire while the user is active. The streak is
+      // deliberately untouched: it counts retry cycles, not turns.
+      if (!refreshTimer) scheduleCodexRefresh(tokens, REFRESH_RETRY_BASE_MS);
       return null;
     }
-    persistCodexOAuthTokens(refreshed);
+    refreshFailureStreak = 0;
+    refreshCapNotified = false;
     scheduleCodexRefresh(refreshed);
     reconnectRequired = false;
     return refreshed.access_token;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import type { Provider } from './types.js';
-import type { Config } from '../config.js';
+import type { Config, ProviderName } from '../config.js';
+import { PROVIDER_NAMES } from '../config.js';
 import { ClaudeProvider } from './claude.js';
 
 export type { Provider, ProviderRunOptions, ProviderMessage, ProviderAuthStatus, ProviderQueryResult } from './types.js';
@@ -12,20 +13,26 @@ export async function getProvider(config: Config): Promise<Provider> {
   return getProviderByName(name);
 }
 
-export async function getProviderByName(name: string): Promise<Provider> {
+export async function getProviderByName(requested: string): Promise<Provider> {
+  // Fall back rather than throw. A config naming a provider that does not exist
+  // used to make every run fail with "Unknown provider" and there was no way to
+  // correct it from inside the app, because changing the setting also needs a
+  // working run. Stored configs can still name providers that were removed, so
+  // this has to degrade to something usable.
+  let name: ProviderName = 'claude';
+  if ((PROVIDER_NAMES as readonly string[]).includes(requested)) {
+    name = requested as ProviderName;
+  } else {
+    console.error(`[provider] unknown provider "${requested}", falling back to claude`);
+  }
+
   if (!providers.has(name)) {
-    switch (name) {
-      case 'claude':
-        providers.set(name, new ClaudeProvider());
-        break;
-      case 'codex': {
-        // Dynamic import to avoid loading codex deps when not needed
-        const { CodexProvider } = await import('./codex.js');
-        providers.set(name, new CodexProvider());
-        break;
-      }
-      default:
-        throw new Error(`Unknown provider: ${name}. Supported: claude, codex`);
+    if (name === 'codex') {
+      // Dynamic import to avoid loading codex deps when not needed
+      const { CodexProvider } = await import('./codex.js');
+      providers.set(name, new CodexProvider());
+    } else {
+      providers.set(name, new ClaudeProvider());
     }
   }
   return providers.get(name)!;

--- a/src/providers/oauth-refresh.ts
+++ b/src/providers/oauth-refresh.ts
@@ -1,0 +1,8 @@
+export function canReuseAccessTokenAfterRefreshFailure(
+  expiresAt: number,
+  refreshRejected: boolean,
+  forceRefresh = false,
+  now = Date.now(),
+): boolean {
+  return !forceRefresh && !refreshRejected && now < expiresAt;
+}

--- a/src/sdk-env.ts
+++ b/src/sdk-env.ts
@@ -1,0 +1,108 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { mergeSkillEnv } from './skills/env.js';
+import { TMP_DIR } from './workspace.js';
+
+
+// Resolve shell PATH once at startup (Electron apps get minimal /usr/bin:/bin:/usr/sbin:/sbin)
+let _resolvedShellPath: string | null = null;
+export function getShellPath(): string {
+  if (_resolvedShellPath !== null) return _resolvedShellPath;
+  const currentPath = process.env.PATH || '';
+
+  // If PATH already has common node locations, skip shell resolution
+  if (currentPath.includes('nvm') || currentPath.includes('homebrew') || currentPath.includes('fnm') || currentPath.includes('/usr/local/bin')) {
+    _resolvedShellPath = currentPath;
+    return _resolvedShellPath;
+  }
+
+  // Resolve from login shell
+  try {
+    const shell = process.env.SHELL || '/bin/zsh';
+    _resolvedShellPath = execSync(`${shell} -lc 'echo -n $PATH'`, {
+      timeout: 5000,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    _resolvedShellPath = currentPath;
+  }
+
+  // Append common node binary locations as fallback
+  const fallbackPaths = [
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+    `${process.env.HOME}/.nvm/current/bin`,
+    `${process.env.HOME}/.fnm/current/bin`,
+    `${process.env.HOME}/.volta/bin`,
+    `${process.env.HOME}/.local/bin`,
+  ];
+  for (const p of fallbackPaths) {
+    if (!_resolvedShellPath.includes(p)) {
+      _resolvedShellPath += `:${p}`;
+    }
+  }
+
+  return _resolvedShellPath;
+}
+
+// Resolve full environment from user's login shell once at startup.
+// macOS GUI apps (Electron) inherit a minimal launchd env that's missing
+// everything the user sets in .zshrc / .bash_profile (NVM, GOPATH, etc.).
+let _resolvedShellEnv: Record<string, string> | null = null;
+export function getShellEnv(): Record<string, string> {
+  if (_resolvedShellEnv) return { ..._resolvedShellEnv };
+  try {
+    const shell = process.env.SHELL || '/bin/zsh';
+    // Use a unique marker so we ignore any stdout noise from .zshrc/.bashrc
+    // (welcome messages, neofetch, fortune, etc.)
+    const marker = '__DORABOT_ENV_START_8f3a__';
+    const raw = execSync(
+      `${shell} -lc 'echo ${marker} && env'`,
+      { timeout: 5000, encoding: 'utf-8' },
+    );
+    // Only parse lines after the marker
+    const markerIdx = raw.indexOf(marker);
+    const envSection = markerIdx >= 0 ? raw.slice(markerIdx + marker.length + 1) : raw;
+    const env: Record<string, string> = {};
+    // Parse KEY=VALUE lines. Env var names match [A-Za-z_][A-Za-z_0-9]*.
+    // Multiline values are rare; accumulate into the last key when a line
+    // doesn't look like a new variable assignment.
+    let lastKey = '';
+    for (const line of envSection.split('\n')) {
+      const m = line.match(/^([A-Za-z_][A-Za-z_0-9]*)=(.*)/);
+      if (m) {
+        lastKey = m[1];
+        env[lastKey] = m[2];
+      } else if (lastKey && line) {
+        env[lastKey] += '\n' + line;
+      }
+    }
+    _resolvedShellEnv = env;
+  } catch {
+    // Fallback: use process.env as-is
+    _resolvedShellEnv = {};
+    for (const [key, val] of Object.entries(process.env)) {
+      if (val !== undefined) _resolvedShellEnv[key] = val;
+    }
+  }
+  return { ..._resolvedShellEnv };
+}
+
+// clean env for SDK subprocess - strip vscode vars that cause file watcher crashes
+export function cleanEnvForSdk(): Record<string, string> {
+  const env = mergeSkillEnv(getShellEnv());
+  // Strip vars that cause issues in the SDK subprocess
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('VSCODE_')) delete env[key];
+  }
+  delete env.GIT_ASKPASS;
+  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.CLAUDECODE;
+  // Ensure PATH includes node binary locations (critical for Electron)
+  env.PATH = getShellPath();
+  // use a clean tmpdir so SDK file watcher doesn't hit socket files
+  const sdkTmp = TMP_DIR;
+  mkdirSync(sdkTmp, { recursive: true });
+  env.TMPDIR = sdkTmp;
+  return env;
+}


### PR DESCRIPTION
Seven bugs that share one shape: something transient or misconfigured happens, a bounded retry runs out or a hard throw fires, and the process latches into a broken state that only quitting and relaunching clears.

Three were reported by @ankit-thebigred in #40, #41 and #42, following his diagnosis in #37. His analysis was correct in each case and those fixes are his, with follow-ups added where reviewing them turned up more. The rest came from chasing a "Not connected to gateway" report.

## What is fixed

**1. The search index was destroyed and rebuilt on every launch** (ref #37, #40)

`messages_fts` is contentless, so `SELECT text_content ... LIMIT 1` always reads back NULL and the "is it populated?" probe was never true. The rebuild branch, which opens with `DROP TABLE`, therefore ran every start, and it loaded every message into one array.

Measured on a 145k-message database: **peak heap 1218MB to 58MB**, and startup after the first run **~1500ms to ~1ms**. Under a 512MB heap cap the old path OOMs outright, which is the crash loop in #37.

Adds a high-water mark so messages with no searchable text are not re-scanned forever, and a lost-index self-heal.

**2. A slow gateway start stranded the app permanently** (ref #41)

`waitForReady()` threw at 20s, the catch scheduled a retry, and `start()` returned immediately at `if (this.process) return` because the process was still alive. A silent no-op: nothing re-checked the socket, the retry counter never advanced, `onError` never fired. Now polls while the process is alive and reports progress via `onSlowStart`, which is also wired up so the tray says so.

**3. A failed OAuth refresh disabled refresh permanently** (ref #42, #38)

The retry cleared the timer and returned, leaving nothing armed. Both common triggers are transient: waking from sleep with DNS not yet up, and concurrent turns spending the same rotating `refresh_token`. The old loop could not help with the second, since it read the token once and resent that same rotated value three times.

Now backs off 30s to 10min without ever disarming, single-flights the refresh, and does not raise `authRequired` for network-class failures, so an overnight offline stretch produces one notification instead of one every five minutes.

The same three faults were present in the Codex provider, which is more exposed because it requires a rotated `refresh_token` on every response. Fixed there too.

**4. Refreshed credentials never reached the CLI** (ref #38)

The SDK does not merge `options.env` with `process.env`, it replaces it. `opts.env` is a login-shell snapshot cached once at startup, so it captures the token from gateway start and never changes. Every refresh was invisible to the subprocess, which kept using the startup token until it expired.

Credentials are now injected into the env the SDK actually spawns with. Note the `cli_keychain` path deliberately does **not** inject: that credential belongs to the CLI, can be a different account, and on an install where dorabot's own tokens have expired, injecting them replaces a working credential with a dead one.

**5. The bridge stopped reconnecting, and the file explorer went silent**

`scheduleReconnect()` gave up after 30 attempts with "Restart the app to try again" and never re-armed. The situations that exhaust 30 attempts are the ones that heal on their own: on one machine 2,905 of 3,609 disconnects are `heartbeat_timeout`, overwhelmingly sleep and wake. Once it fired, every RPC failed with `Not connected to gateway` and anything gated on the connection stopped, including the file explorer's watcher, whose failure was swallowed.

Separately the watcher used `recursive: false`, so changes in any subdirectory produced no event at all; the renderer discarded the `filename` the event already carried, so nothing could tell which directory changed; and the explorer only reloaded when the path equalled the watch root. All three are fixed, and `fs.watch.start` no longer swallows its rejection.

**6. Selecting a provider that was never implemented bricked the app**

`ProviderName` declared four providers, `config.set` accepted three, the factory implemented two. Choosing one of the differences threw `Unknown provider` on every run, and since changing the setting back also needs a working run, there was no way out from inside the app.

`minimax` and `openrouter` are removed along with the unused `OpenRouterProviderConfig`, and the type and the setter's validation now derive from one `PROVIDER_NAMES` const so they cannot drift again. The factory falls back to claude with a log instead of throwing, because a stored config can still name a provider that no longer exists and deleting the type alone would leave those installs exactly as stuck.

**7. `verifyAuth()` could report healthy while every session failed**

It called the SDK with no `env`, so its subprocess inherited `process.env` while real runs receive `opts.env`. The check ran against an environment no session would ever see. That is the confusing half of #38: the UI showing the provider connected while chats returned 401.

It now builds the env with `cleanEnvForSdk()` exactly as a run does and selects the credential through the same shared function, so a pass means a run would pass. This required extracting the env builder to `src/sdk-env.ts`, since the provider cannot import `agent.ts`, which imports the provider. `agent.ts` loses 107 lines.

## Verification

Six of the seven have runtime evidence rather than build-only checks.

- **FTS**: real compiled `backfillFtsIndex` against copies of a real 1.1GB database. First run 1543ms, then 1ms; wipe the index and it self-heals; the mark advances correctly past 500 messages inserted live.
- **Auth refresh + env delivery**: a real Claude turn end to end, first assistant message at 3685ms, result `subtype=success is_error=false`, with the spawned child's environment probed via `ps eww`.
- **Reconnect**: A/B against `main` with the gateway down. `main` stops at attempt 30 with no timer armed; this branch reaches 31 and stays armed, then reconnects on its own 44s after the gateway returns, with no app restart.
- **fs watcher**: A/B against `main` over the real RPC with real files. `main` fails 4 of 5 cases (subdir, 2-levels-deep, new subdir, delete); this branch passes all 5 with correct relative paths.
- **Provider**: reproduced the throw, then verified over real RPC that the setter rejects the removed names and that a stored `minimax` config now resolves to claude instead of failing.
- **verifyAuth**: A/B reading the child's real environment, using `CLAUDECODE` as the discriminator since `cleanEnvForSdk` deletes it and a raw `process.env` keeps it. `main` leaks it, this branch does not, and both still report authenticated.

Backend and desktop typecheck and both builds pass at **every** commit, so bisect stays clean.

`fix(desktop): recover when the gateway is slow to start` is the one without runtime evidence. It needs a genuinely slow gateway start inside Electron, which I could not force cleanly.

## Ordering

Commits 1 and 2 should land together. `backfillFtsIndex()` runs long before `httpServer.listen()`, so the index fix is what stops startup crossing the readiness timeout that commit 2 makes survivable.

## Known and deliberately not included

- `_cliHasAuth` is cached for the process lifetime, so logging into the CLI while dorabot runs is never noticed.
- `gateway-manager` increments `retries` in both the exit handler and the catch, halving the retry budget on a real crash.
- `runAgent()` does not return after a successful `result` message. Reproduced on `main` as well, so pre-existing.
- The refresh single-flight is per process; a separate CLI can still race it.
- A stale `messages_fts_after_delete` trigger makes `DELETE FROM messages` throw on databases created in a particular window, breaking session deletion. Not created by current code, so fresh installs are unaffected.