### PR TITLE
Close the path-guard bypasses and the fail-open sender check

### DIFF
--- a/src/channels/telegram/monitor.ts
+++ b/src/channels/telegram/monitor.ts
@@ -66,19 +66,31 @@ export async function startTelegramMonitor(opts: TelegramMonitorOptions): Promis
     },
   });
 
+  // an allowFrom of [] means "nobody is authorized", so it has to reject everyone.
+  // treating it as unset would fail open and hand a full agent run to any stranger
+  // who messages the bot.
+  function senderAllowed(senderId: string): boolean {
+    if (!opts.allowFrom) return true;
+    if (opts.allowFrom.length === 0) {
+      console.log('[telegram] no authorized senders configured, rejecting all messages');
+      return false;
+    }
+    return opts.allowFrom.includes(senderId);
+  }
+
   // bot commands
   if (opts.onCommand) {
     const onCmd = opts.onCommand;
     bot.command('new', async (ctx) => {
       const senderId = String(ctx.from?.id || '');
-      if (opts.allowFrom && opts.allowFrom.length > 0 && !opts.allowFrom.includes(senderId)) return;
+      if (!senderAllowed(senderId)) return;
       const chatId = String(ctx.chat.id);
       const reply = await onCmd('new', chatId);
       if (reply) await ctx.reply(reply);
     });
     bot.command('status', async (ctx) => {
       const senderId = String(ctx.from?.id || '');
-      if (opts.allowFrom && opts.allowFrom.length > 0 && !opts.allowFrom.includes(senderId)) return;
+      if (!senderAllowed(senderId)) return;
       const chatId = String(ctx.chat.id);
       const reply = await onCmd('status', chatId);
       if (reply) await ctx.reply(reply);
@@ -138,11 +150,9 @@ export async function startTelegramMonitor(opts: TelegramMonitorOptions): Promis
     const isGroup = chat.type === 'group' || chat.type === 'supergroup';
     if (isGroup && opts.groupPolicy === 'disabled') return null;
     const senderId = String(msg.from?.id || '');
-    if (opts.allowFrom && opts.allowFrom.length > 0) {
-      if (!opts.allowFrom.includes(senderId)) {
-        console.log(`[telegram] unauthorized sender: ${senderId} (${msg.from?.first_name || 'unknown'})`);
-        return null;
-      }
+    if (!senderAllowed(senderId)) {
+      console.log(`[telegram] unauthorized sender: ${senderId} (${msg.from?.first_name || 'unknown'})`);
+      return null;
     }
     return { chat, isGroup, senderId };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, basename, sep } from 'node:path';
 import {
   DORABOT_CONFIG_PATH,
   GATEWAY_SOCKET_PATH,
@@ -346,29 +346,55 @@ export const ALWAYS_DENIED = [
   '~/.config/nanoclaw',
 ];
 
+// resolve symlinks, including for paths that don't exist yet. a plain realpath throws
+// on ENOENT, which is every create-a-new-file write, so we walk up to the nearest
+// existing ancestor and re-append the tail. otherwise ~/work/link/authorized_keys
+// passes the check while the write lands wherever link points.
+function canonicalize(p: string): string {
+  const abs = resolve(p);
+  const tail: string[] = [];
+  let cur = abs;
+  for (;;) {
+    try {
+      const real = realpathSync(cur);
+      return tail.length ? join(real, ...tail) : real;
+    } catch {}
+    const parent = dirname(cur);
+    if (parent === cur) return abs;
+    tail.unshift(basename(cur));
+    cur = parent;
+  }
+}
+
+// match on segment boundaries so /tmp doesn't also cover /tmpfoo
+function isUnder(target: string, prefix: string, ignoreCase: boolean): boolean {
+  const t = ignoreCase ? target.toLowerCase() : target;
+  const p = ignoreCase ? prefix.toLowerCase() : prefix;
+  if (t === p) return true;
+  return t.startsWith(p.endsWith(sep) ? p : p + sep);
+}
+
 export function isPathAllowed(
   targetPath: string,
   config: Config,
   channelOverride?: { allowedPaths?: string[]; deniedPaths?: string[] },
 ): boolean {
   const home = homedir();
-  let resolved: string;
-  try {
-    resolved = realpathSync(targetPath);
-  } catch {
-    resolved = resolve(targetPath);
-  }
+  const resolved = canonicalize(targetPath);
 
   // denied: always_denied + global + channel-specific (all merged)
   const globalDenied = [...ALWAYS_DENIED, ...(config.gateway?.deniedPaths || [])];
   const channelDenied = channelOverride?.deniedPaths || [];
-  const denied = [...globalDenied, ...channelDenied].map(p => resolve(p.replace(/^~/, home)));
-  if (denied.some(d => resolved.startsWith(d))) return false;
+  const denied = [...globalDenied, ...channelDenied].map(p => canonicalize(p.replace(/^~/, home)));
+  // deny ignores case: macos filesystems are case-insensitive by default, so ~/.SSH
+  // and ~/.ssh are the same bytes on disk and realpath does not normalize between them
+  if (denied.some(d => isUnder(resolved, d, true))) return false;
 
   // allowed: channel-specific overrides global if set
   const allowedRaw = channelOverride?.allowedPaths?.length
     ? channelOverride.allowedPaths
     : (config.gateway?.allowedPaths || [home, '/tmp']);
-  const allowed = allowedRaw.map(p => resolve(p.replace(/^~/, home)));
-  return allowed.some(a => resolved.startsWith(a));
+  const allowed = allowedRaw.map(p => canonicalize(p.replace(/^~/, home)));
+  // allow stays case-sensitive so this never grants more than it was configured to
+  return allowed.some(a => isUnder(resolved, a, false));
 }

--- a/src/gateway/tool-policy.ts
+++ b/src/gateway/tool-policy.ts
@@ -82,10 +82,23 @@ export function classifyToolCall(
     return 'require-approval';
   }
 
-  if (name === 'schedule_reminder' ||
-      name === 'schedule_recurring' ||
-      name === 'schedule_cron') {
+  // these are the names the calendar tools actually register under. the old list
+  // (schedule_reminder/schedule_recurring/schedule_cron) matched nothing, so
+  // scheduling persistence was silently auto-allowed.
+  if (name === 'schedule' ||
+      name === 'update_schedule' ||
+      name === 'cancel_schedule') {
     return 'require-approval';
+  }
+
+  // outbound messaging leaves the machine, and attaching a file makes it an
+  // exfiltration path. notify at minimum, approve when it carries a payload.
+  if (name === 'message') {
+    const action = (input.action as string) || '';
+    if (action === 'send') {
+      return input.media ? 'require-approval' : 'notify';
+    }
+    return 'notify';
   }
 
   return 'auto-allow';

--- a/src/tools/messaging.ts
+++ b/src/tools/messaging.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { tool } from '@anthropic-ai/claude-agent-sdk';
+import { loadConfig, isPathAllowed } from '../config.js';
 
 export type ChannelHandler = {
   send(target: string, message: string, opts?: { media?: string; replyTo?: string }): Promise<{ id: string; chatId: string }>;
@@ -62,6 +63,19 @@ export const messageTool = tool(
               content: [{ type: 'text', text: 'Error: target and message required for send' }],
               isError: true,
             };
+          }
+          // an attachment is the one part of this tool that reads the disk and puts
+          // the bytes on the network, so it gets the same path rules as file access.
+          // this is deliberately not tied to approvalMode: autonomous should still
+          // not be able to mail out ~/.ssh.
+          if (args.media) {
+            const config = await loadConfig();
+            if (!isPathAllowed(args.media, config)) {
+              return {
+                content: [{ type: 'text', text: `Error: not allowed to attach ${args.media}` }],
+                isError: true,
+              };
+            }
           }
           const result = await handler.send(target, args.message, {
             media: args.media,


### PR DESCRIPTION
Follow-up to the audit behind #44. These are the code-level holes, verified against the running build before and after.

### The case bypass

`isPathAllowed` resolved the target with `realpathSync` and then did a case-sensitive `startsWith` against the deny list. macOS filesystems are case-insensitive by default and realpath does **not** normalize case, so a different capitalization reached the same bytes on disk while missing every deny prefix.

Run against the guard as it shipped:

```
DENY   ~/.ssh/id_ed25519          ALLOW  ~/.SSH/id_ed25519
DENY   ~/.dorabot/gateway-token   ALLOW  ~/.dorabot/Gateway-Token
DENY   ~/.aws/credentials         ALLOW  ~/.AWS/credentials
```

Every `ALWAYS_DENIED` entry fell to this. Deny matching now ignores case; allow matching stays case-sensitive so the check never grants more than it was configured to.

### Three more in the same function

- `realpathSync` threw on ENOENT and fell back to a lexical `resolve()`. That is *every* create-a-new-file write, so `~/work/link/authorized_keys` with `link -> ~/.ssh` passed the check and the write followed the symlink. Now canonicalizes via the nearest existing ancestor.
- Prefix matching had no separator boundary, so `/tmp` also admitted `/tmpfoo`.
- The allow/deny prefixes were never resolved themselves. That is why `/tmp` was broken in both directions on macOS: `/tmp` is a symlink to `/private/tmp`, so reads of existing files resolved out of the allowlist and were denied, while new files stayed lexically `/tmp` and passed. Screenshots could be created there but not read back.

### Fail-open sender check

An empty `allowFrom` on Telegram fell through to allow-everyone, which is the opposite of what an empty allowlist means and the opposite of what WhatsApp already did with the same value. That asymmetry meant the safe-looking config was the dangerous one.

### Approval tiers that matched nothing

`tool-policy` gated `schedule_reminder` / `schedule_recurring` / `schedule_cron`. The calendar tools register as `schedule` / `update_schedule` / `cancel_schedule`, so scheduling persistence was silently auto-allowed at every tier.

`message` fell through to `auto-allow`. Since lockdown only gates `tier !== 'auto-allow'`, outbound messaging was ungated even in lockdown, and `media` accepted any path. The attachment check is enforced **in the tool** rather than in the approval tier, because `autonomous` mode should still not be able to mail out `~/.ssh`.

### Verification

`tsc --noEmit` clean. Guard re-probed after the change, 13/13 including the regression cases:

```
ok  DENY  ~/.SSH/id_ed25519              ok  DENY  /tmp/probelink/sshlink/id_ed25519
ok  DENY  ~/.dorabot/Gateway-Token       ok  ALLOW /tmp/existing-screenshot.png
ok  DENY  /tmpfoo/x                      ok  ALLOW /tmp/new-file-does-not-exist.png
ok  DENY  ~/.AWS/credentials             ok  ALLOW ~/.ssh-backup/x
```

`/tmp` now works in both directions, and `~/.ssh-backup` is no longer over-denied by the missing boundary.

### Not in scope

`shell.spawn` takes an unvalidated `cwd` and `shell.write` pipes into a login shell inheriting `process.env`, so an authenticated client still has shell-equivalent reach and these rules remain advisory against it. The real boundary there is the socket's 0600 mode and the owning UID. This PR fixes the paths reachable from the tool layer and the desktop UI, where shell-equivalent reach is not expected.